### PR TITLE
Edit inventory generation and menu properties

### DIFF
--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
@@ -24,6 +24,7 @@ abstract class Receptacle<Element>(val layout: ReceptacleLayout) {
     abstract fun refresh(slot: Int = -1)
     abstract fun open(player: Player)
     abstract fun close(sendPacket: Boolean = true)
+    abstract fun title(value: String, update: Boolean = true)
     abstract fun callEventClick(event: ReceptacleInteractEvent<Element>)
 
 

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
@@ -25,6 +25,7 @@ abstract class Receptacle<Element>(val layout: ReceptacleLayout) {
     abstract fun open(player: Player)
     abstract fun close(sendPacket: Boolean = true)
     abstract fun title(value: String, update: Boolean = true)
+    abstract fun property(id: Int, value: Int)
     abstract fun callEventClick(event: ReceptacleInteractEvent<Element>)
 
 

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/ReceptacleClickType.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/ReceptacleClickType.kt
@@ -1,57 +1,60 @@
 package trplugins.menu.api.receptacle
 
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryAction
+
 /**
  * @author Arasple
  * @date 2020/12/5 22:01
  */
-enum class ReceptacleClickType(private val mode: Int, private val button: Int) {
+enum class ReceptacleClickType(private val mode: Int, private val button: Int, private val type: ClickType? = null, private val action: Any? = null) {
 
     ALL(-1, -1),
 
-    LEFT(0, 0),
+    LEFT(0, 0, ClickType.LEFT),
 
-    RIGHT(0, 1),
+    RIGHT(0, 1, ClickType.RIGHT),
 
-    SHIFT_LEFT(1, 0),
+    SHIFT_LEFT(1, 0, ClickType.SHIFT_LEFT),
 
-    SHIFT_RIGHT(1, 1),
+    SHIFT_RIGHT(1, 1, ClickType.SHIFT_RIGHT),
 
-    OFFHAND(2, 40),
+    OFFHAND(2, 40, ClickType.SWAP_OFFHAND),
 
-    NUMBER_KEY(2, -1),
+    NUMBER_KEY(2, -1, ClickType.NUMBER_KEY, -1),
 
-    NUMBER_KEY_1(2, 0),
+    NUMBER_KEY_1(2, 0, ClickType.NUMBER_KEY, 0),
 
-    NUMBER_KEY_2(2, 1),
+    NUMBER_KEY_2(2, 1, ClickType.NUMBER_KEY, 1),
 
-    NUMBER_KEY_3(2, 2),
+    NUMBER_KEY_3(2, 2, ClickType.NUMBER_KEY, 2),
 
-    NUMBER_KEY_4(2, 3),
+    NUMBER_KEY_4(2, 3, ClickType.NUMBER_KEY, 3),
 
-    NUMBER_KEY_5(2, 4),
+    NUMBER_KEY_5(2, 4, ClickType.NUMBER_KEY, 4),
 
-    NUMBER_KEY_6(2, 5),
+    NUMBER_KEY_6(2, 5, ClickType.NUMBER_KEY, 5),
 
-    NUMBER_KEY_7(2, 6),
+    NUMBER_KEY_7(2, 6, ClickType.NUMBER_KEY, 6),
 
-    NUMBER_KEY_8(2, 7),
+    NUMBER_KEY_8(2, 7, ClickType.NUMBER_KEY, 7),
 
-    NUMBER_KEY_9(2, 8),
+    NUMBER_KEY_9(2, 8, ClickType.NUMBER_KEY, 8),
 
-    MIDDLE(3, 2),
+    MIDDLE(3, 2, ClickType.MIDDLE),
 
     // clicked Item will be empty
-    DROP(4, 0),
+    DROP(4, 0, ClickType.DROP),
 
-    CONTROL_DROP(4, 1),
+    CONTROL_DROP(4, 1, ClickType.CONTROL_DROP),
 
-    ABROAD_LEFT_EMPTY(4, 0),
+    ABROAD_LEFT_EMPTY(4, 0, ClickType.DROP, InventoryAction.DROP_ONE_SLOT),
 
-    ABROAD_RIGHT_EMPTY(4, 1),
+    ABROAD_RIGHT_EMPTY(4, 1, ClickType.CONTROL_DROP, InventoryAction.DROP_ALL_SLOT),
 
-    ABROAD_LEFT_ITEM(0, 0),
+    ABROAD_LEFT_ITEM(0, 0, ClickType.LEFT, InventoryAction.DROP_ALL_CURSOR),
 
-    ABROAD_RIGHT_ITEM(0, 1),
+    ABROAD_RIGHT_ITEM(0, 1, ClickType.RIGHT, InventoryAction.DROP_ONE_CURSOR),
 
     LEFT_MOUSE_DRAG_ADD(5, 1),
 
@@ -59,12 +62,20 @@ enum class ReceptacleClickType(private val mode: Int, private val button: Int) {
 
     MIDDLE_MOUSE_DRAG_ADD(5, 9),
 
-    DOUBLE_CLICK(6, 0),
+    DOUBLE_CLICK(6, 0, ClickType.DOUBLE_CLICK),
 
     UNKNOWN(-1, -1);
 
+    fun toBukkitType(): ClickType {
+        return this.type ?: ClickType.UNKNOWN
+    }
+
     fun equals(mode: Int, button: Int): Boolean {
         return this.mode == mode && this.button == button
+    }
+
+    fun equals(type: ClickType?, action: Any?): Boolean {
+        return this.type == type && this.action == action
     }
 
     fun isRightClick(): Boolean {
@@ -84,7 +95,7 @@ enum class ReceptacleClickType(private val mode: Int, private val button: Int) {
     }
 
     fun isNumberKeyClick(): Boolean {
-        return this.name.startsWith("NUMBER_KEY") || this == OFFHAND
+        return this.type == ClickType.NUMBER_KEY || this == OFFHAND
     }
 
     private fun isDoubleClick(): Boolean {
@@ -102,6 +113,7 @@ enum class ReceptacleClickType(private val mode: Int, private val button: Int) {
     companion object {
 
         private val modes = arrayOf("PICKUP", "QUICK_MOVE", "SWAP", "CLONE", "THROW", "QUICK_CRAFT", "PICKUP_ALL")
+        private val actions = setOf(InventoryAction.DROP_ALL_CURSOR, InventoryAction.DROP_ONE_CURSOR, InventoryAction.DROP_ONE_SLOT, InventoryAction.DROP_ALL_SLOT)
 
         private fun matchesFirst(string: String): ReceptacleClickType {
             return entries.find { it.name.equals(string, true) } ?: ALL
@@ -126,6 +138,17 @@ enum class ReceptacleClickType(private val mode: Int, private val button: Int) {
                 }
             }
             return entries.find { it.equals(mode, button) }
+        }
+
+        fun from(type: ClickType?, action: InventoryAction?, slot: Int = -1): ReceptacleClickType? {
+            val act: Any? = if (type == ClickType.NUMBER_KEY) {
+                slot
+            } else if (actions.contains(action)) {
+                action
+            } else {
+                null
+            }
+            return entries.find { it.equals(type, act) }
         }
     }
 }

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/NMS.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/NMS.kt
@@ -2,6 +2,7 @@ package trplugins.menu.api.receptacle.vanilla.window
 
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
+import trplugins.menu.api.receptacle.provider.PlatformProvider
 
 /**
  * @author Arasple
@@ -9,6 +10,22 @@ import org.bukkit.inventory.ItemStack
  */
 abstract class NMS {
 
+    companion object {
+        var javaStaticInventory: Boolean = false
+        var bedrockStaticInventory: Boolean = false
+        var createIdPacketInventory: Boolean = false
+
+        fun Player.useStaticInventory() = if (PlatformProvider.isBedrockPlayer(this)) bedrockStaticInventory else javaStaticInventory
+
+        fun createWindowId(): Boolean {
+            return createIdPacketInventory
+        }
+    }
+
+    /**
+     * Get current window id from player o create a new one
+     */
+    abstract fun windowId(player: Player, create: Boolean = false): Int
 
     /**
      * This packet is sent by the client when closing a window.
@@ -17,7 +34,7 @@ abstract class NMS {
      *
      * This is the ID of the window that was closed. 0 for player inventory.
      */
-    abstract fun sendWindowsClose(player: Player, windowId: Int = 119)
+    abstract fun sendWindowsClose(player: Player, windowId: Int = windowId(player))
 
     /**
      * Sent by the server when items in multiple slots (in a window) are added/removed.
@@ -27,7 +44,7 @@ abstract class NMS {
      *
      * @param items Array of Slot
      */
-    abstract fun sendWindowsItems(player: Player, windowId: Int = 119, items: Array<ItemStack?>)
+    abstract fun sendWindowsItems(player: Player, windowId: Int = windowId(player), items: Array<ItemStack?>)
 
     /**
      * This is sent to the client when it should open an inventory,
@@ -39,7 +56,7 @@ abstract class NMS {
      * @param type The window type to use for display. See ReceptacleType for the different values.
      * @param title The title of the window
      */
-    abstract fun sendWindowsOpen(player: Player, windowId: Int = 119, type: WindowLayout, title: String)
+    abstract fun sendWindowsOpen(player: Player, windowId: Int = windowId(player, true), type: WindowLayout, title: String)
 
     /**
      * Sent by the server when an item in a slot (in a window) is added/removed.
@@ -53,13 +70,13 @@ abstract class NMS {
      * @param slot The slot that should be updated
      * @param itemStack The to update item stack
      */
-    abstract fun sendWindowsSetSlot(player: Player, windowId: Int = 119, slot: Int, itemStack: ItemStack? = null, stateId: Int = 1)
+    abstract fun sendWindowsSetSlot(player: Player, windowId: Int = windowId(player), slot: Int, itemStack: ItemStack? = null, stateId: Int = 1)
 
     /**
      * https://wiki.vg/Protocol#Window_Property
      *
      * TODO This packet is used to inform the client that part of a GUI window should be updated.
      */
-    abstract fun sendWindowsUpdateData(player: Player, windowId: Int = 119, property: Int, value: Int)
+    abstract fun sendWindowsUpdateData(player: Player, windowId: Int = windowId(player), property: Int, value: Int)
 
 }

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/NMS.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/NMS.kt
@@ -75,8 +75,9 @@ abstract class NMS {
     /**
      * https://wiki.vg/Protocol#Window_Property
      *
-     * TODO This packet is used to inform the client that part of a GUI window should be updated.
+     * Send by the server to inform the client that part of a GUI window should be updated.
+     * The meaning of the Property field depends on the type of the window.
      */
-    abstract fun sendWindowsUpdateData(player: Player, windowId: Int = windowId(player), property: Int, value: Int)
+    abstract fun sendWindowsUpdateData(player: Player, windowId: Int = windowId(player), id: Int, value: Int)
 
 }

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/StaticInventory.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/StaticInventory.kt
@@ -5,13 +5,14 @@ import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryType
 import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.InventoryHolder
-import taboolib.library.reflex.Reflex.Companion.getProperty
+import org.bukkit.inventory.InventoryView
 
 object StaticInventory {
 
     private val inventories = HashMap<String, Holder>()
 
     val Player.staticInventory get() = inventories[this.name]?.inventory
+    val Player.inventoryView get() = inventories[this.name]?.view
 
     fun open(player: Player, layout: WindowLayout, title: String) {
         val holder = Holder(layout, title)
@@ -30,17 +31,20 @@ object StaticInventory {
             InventoryType.CHEST -> Bukkit.createInventory(this, layout.slotRange.last + 1, title)
             else -> Bukkit.createInventory(this, type, title)
         }
+        var view: InventoryView? = null
+            private set
 
         override fun getInventory(): Inventory {
             return inventory
         }
 
         fun open(player: Player) {
-            player.openInventory(inventory)
+            view = player.openInventory(inventory)
         }
 
         fun clear() {
             inventory.clear()
+            view = null
         }
     }
 }

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/StaticInventory.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/StaticInventory.kt
@@ -11,7 +11,6 @@ object StaticInventory {
 
     private val inventories = HashMap<String, Holder>()
 
-    val Player.staticContainerId get() = inventories[this.name]?.containerId
     val Player.staticInventory get() = inventories[this.name]?.inventory
 
     fun open(player: Player, layout: WindowLayout, title: String) {
@@ -31,8 +30,6 @@ object StaticInventory {
             InventoryType.CHEST -> Bukkit.createInventory(this, layout.slotRange.last + 1, title)
             else -> Bukkit.createInventory(this, type, title)
         }
-        var containerId: Int? = null
-            private set
 
         override fun getInventory(): Inventory {
             return inventory
@@ -40,12 +37,10 @@ object StaticInventory {
 
         fun open(player: Player) {
             player.openInventory(inventory)
-            containerId = player.getProperty<Int>("entity/containerCounter")!!
         }
 
         fun clear() {
             inventory.clear()
-            containerId = null
         }
     }
 }

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
@@ -12,7 +12,7 @@ import trplugins.menu.api.receptacle.setViewingReceptacle
  * @author Arasple
  * @date 2020/11/29 10:38
  */
-open class WindowReceptacle(var type: WindowLayout, title: String = type.toBukkitType().defaultTitle) : Receptacle<ItemStack>(type) {
+open class WindowReceptacle(var type: WindowLayout, override var title: String = type.toBukkitType().defaultTitle) : Receptacle<ItemStack>(type) {
 
     private var viewer: Player? = null
 
@@ -29,14 +29,6 @@ open class WindowReceptacle(var type: WindowLayout, title: String = type.toBukki
     private var stateId = 1
         get() {
             return field++
-        }
-
-    override var title = title
-        set(value) {
-            field = value
-            submit(delay = 3, async = true) {
-                initializationPackets()
-            }
         }
 
     fun hidePlayerInventory(hidePlayerInventory: Boolean) {
@@ -93,6 +85,15 @@ open class WindowReceptacle(var type: WindowLayout, title: String = type.toBukki
             }
             onClose(viewer!!, this)
             viewer!!.setViewingReceptacle(null)
+        }
+    }
+
+    override fun title(value: String, update: Boolean) {
+        title = value
+        if (update) {
+            submit(delay = 3, async = true) {
+                initializationPackets()
+            }
         }
     }
 

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
@@ -97,6 +97,12 @@ open class WindowReceptacle(var type: WindowLayout, override var title: String =
         }
     }
 
+    override fun property(id: Int, value: Int) {
+        if (viewer != null) {
+            nmsProxy<NMS>().sendWindowsUpdateData(viewer!!, id = id, value = value)
+        }
+    }
+
     override fun callEventClick(event: ReceptacleInteractEvent<ItemStack>) {
         if (viewer != null) {
             onClick(viewer!!, event)

--- a/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
+++ b/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
@@ -43,6 +43,11 @@ enum class Property(val default: String, val regex: Regex) {
     SIZE("Size", "(size|row)s?"),
 
     /**
+     * 菜单类型属性
+     */
+    PROPERTIES("Properties", "propert(y|ies?)"),
+
+    /**
      * 菜单选项设置
      */
     OPTIONS("Options", "(option|setting)s?"),
@@ -266,6 +271,10 @@ enum class Property(val default: String, val regex: Regex) {
 
     fun ofMap(conf: Configuration?, deep: Boolean = false): Map<String, Any?> {
         return ofSection(conf)?.getValues(deep) ?: mapOf()
+    }
+
+    fun <K, V> ofMap(conf: Configuration?, deep: Boolean = false, keyTransform: (String) -> K = { it as K }, valueTransform: (Any?) -> V = { it as V }): Map<K, V> {
+        return ofMap(conf, deep).mapKeys { keyTransform(it.key) }.mapValues { valueTransform(it.value) }
     }
 
     fun ofLists(conf: Configuration?): List<List<String>> {

--- a/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
@@ -8,9 +8,12 @@ import taboolib.module.configuration.Configuration
 import taboolib.module.kether.Kether
 import taboolib.module.lang.Language
 import taboolib.module.lang.sendLang
+import taboolib.module.nms.nmsProxy
 import taboolib.platform.BukkitPlugin
 import trplugins.menu.api.action.ActionHandle
 import trplugins.menu.api.receptacle.provider.PlatformProvider
+import trplugins.menu.api.receptacle.vanilla.window.NMS
+import trplugins.menu.api.receptacle.vanilla.window.NMSImpl
 import trplugins.menu.module.conf.Loader
 import trplugins.menu.module.conf.prop.RunningPerformance
 import trplugins.menu.module.display.MenuSession
@@ -74,11 +77,10 @@ object TrMenu : Plugin() {
         Shortcuts.Type.load()
         RegisterCommands.load()
         Kether.isAllowToleranceParser = SETTINGS.getBoolean("Action.Kether.Allow-Tolerance-Parser", false)
-        if (SETTINGS.getBoolean("Options.Bedrock-Static-Inv", false)) {
-            PlatformProvider.compute()
-        } else {
-            PlatformProvider.provider = null
-        }
+        PlatformProvider.compute()
+        NMS.javaStaticInventory = SETTINGS.getBoolean("Options.Static-Inventory.Java", false)
+        NMS.bedrockStaticInventory = SETTINGS.getBoolean("Options.Static-Inventory.Bedrock", false)
+        NMS.createIdPacketInventory = SETTINGS.getBoolean("Options.Packet-Inventory.Create-Id", false)
     }
 
 }

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetProperty.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetProperty.kt
@@ -1,0 +1,35 @@
+package trplugins.menu.api.action.impl.menu
+
+import org.bukkit.inventory.InventoryView
+import taboolib.common.platform.ProxyPlayer
+import trplugins.menu.api.action.ActionHandle
+import trplugins.menu.api.action.base.ActionBase
+import trplugins.menu.api.action.base.ActionContents
+import trplugins.menu.module.display.session
+
+/**
+ * TrMenu
+ * trplugins.menu.api.action.impl.menu.SetProperty
+ *
+ * @author Rubenicos
+ * @since 2024/02/29 08:42
+ */
+class SetProperty(handle: ActionHandle) : ActionBase(handle) {
+
+    override val regex = "set-?property".toRegex()
+
+    override fun onExecute(contents: ActionContents, player: ProxyPlayer, placeholderPlayer: ProxyPlayer) {
+        val session = player.session()
+        val receptacle = session.receptacle ?: return
+
+        val args = contents.stringContent().parseContent(placeholderPlayer).split(" ", limit = 2)
+        if (args.size < 2) return
+
+        val name = args[0].replace('-', '_')
+        val id = name.toIntOrNull() ?: (InventoryView.Property.entries.find { it.name.equals(name, ignoreCase = true) } ?: return).id
+        val value = args[1].toIntOrNull() ?: return
+
+        receptacle.property(id, value)
+    }
+
+}

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetTitle.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetTitle.kt
@@ -21,7 +21,7 @@ class SetTitle(handle: ActionHandle) : ActionBase(handle) {
         val session = player.session()
         val receptacle = session.receptacle ?: return
 
-        receptacle.title = contents.stringContent().parseContent(placeholderPlayer)
+        receptacle.title(contents.stringContent().parseContent(placeholderPlayer))
     }
 
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -1,6 +1,7 @@
 package trplugins.menu.module.conf
 
 import org.bukkit.event.inventory.InventoryType
+import org.bukkit.inventory.InventoryView
 import org.bukkit.inventory.ItemFlag
 import taboolib.common.platform.function.pluginId
 import taboolib.common.util.asList
@@ -103,6 +104,13 @@ object MenuSerializer : ISerializer {
         val funs = Property.FUNCTIONS.ofMap(conf, true)
         val title = Property.TITLE.ofStringList(conf, listOf(pluginId))
         val titleUpdate = Property.TITLE_UPDATE.ofInt(conf, -20)
+        val properties = Property.PROPERTIES.ofMap(conf,
+            keyTransform = { key ->
+                val name = key.replace('-', '_')
+                InventoryView.Property.entries.find { it.name.equals(name, ignoreCase = true) }?.id ?: -1
+            },
+            valueTransform = { value -> value.toString().toIntOrNull() }
+        )
         val optionEnableArguments = Property.OPTION_ENABLE_ARGUMENTS.ofBoolean(options, true)
         val optionDefaultArguments = Property.OPTION_DEFAULT_ARGUMENTS.ofStringList(options)
         val optionFreeSlots = Property.OPTION_FREE_SLOTS.ofStringList(conf)
@@ -120,6 +128,7 @@ object MenuSerializer : ISerializer {
         result.result = MenuSettings(
             CycleList(title),
             titleUpdate,
+            properties,
             optionEnableArguments,
             optionDefaultArguments.toTypedArray(),
             optionFreeSlots.flatMap { Position.Slot.readStaticSlots(it) }.toSet(),

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -135,9 +135,11 @@ class Menu(
      * 加载容器标题 & 自动更新
      */
     private fun loadTitle(session: MenuSession) {
+        session.receptacle?.title(settings.title.next(session.id)?.let { session.parse(it) } ?: pluginId, update = false)
+        
         val setTitle = {
-            session.receptacle?.title = settings.title.next(session.id)?.let { session.parse(it) } ?: pluginId
-        }.also { it.invoke() }
+            session.receptacle?.title(settings.title.next(session.id)?.let { session.parse(it) } ?: pluginId)
+        }
 
         if (settings.titleUpdate > 0 && settings.title.cyclable()) {
             session.arrange(submit(delay = 10, period = settings.titleUpdate.toLong(), async = true) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -92,6 +92,11 @@ class Menu(
                 loadTasks(session)
 
                 receptacle.open(viewer)
+                settings.properties.forEach { (id, value) ->
+                    if (id >= 0 && value != null) {
+                        receptacle.property(id, value)
+                    }
+                }
             }
         }
     }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
@@ -19,6 +19,7 @@ import trplugins.menu.util.collections.CycleList
 class MenuSettings(
     val title: CycleList<String>,
     val titleUpdate: Int,
+    val properties: Map<Int, Int?>,
     val enableArguments: Boolean = true,
     val defaultArguments: Array<String> = arrayOf(),
     val freeSlots: Set<Int> = setOf(),

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/command/impl/CommandTest.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/command/impl/CommandTest.kt
@@ -27,7 +27,7 @@ object CommandTest : CommandExpression {
             chest.open(player)
 
             val task = submit(delay = 20, period = 10, async = false) {
-                chest.title = (0..20).random().toString()
+                chest.title((0..20).random().toString())
             }
             submit(delay = (20 * 20)) {
                 task.cancel()

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerBukkitInventory.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerBukkitInventory.kt
@@ -6,6 +6,7 @@ import org.bukkit.event.inventory.InventoryOpenEvent
 import org.bukkit.event.player.PlayerChangedWorldEvent
 import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
+import trplugins.menu.api.receptacle.vanilla.window.NMS.Companion.useStaticInventory
 import trplugins.menu.module.display.MenuSession
 
 /**
@@ -18,6 +19,7 @@ object ListenerBukkitInventory {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun e(e: InventoryOpenEvent) {
         val player = e.player as Player
+        if (player.useStaticInventory()) return
 
         MenuSession.getSession(player).close(closePacket = true, updateInventory = true)
     }

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -3,7 +3,11 @@ Options:
   Running-Performance: Normal
   Multi-Thread: true
   Async-Load-Menus: true
-  Bedrock-Static-Inv: false
+  Static-Inventory:
+    Java: false
+    Bedrock: false
+  Packet-Inventory:
+    Create-Id: false
 
   Placeholders:
     JavaScript-Parse: false


### PR DESCRIPTION
### Additions
* Update data packet
* Menu properties
* `set-property` menu action
* Option to use player internal container id as window id
* Option to send static inventories to Java players

### Changes
* Now static inventories are completely managed using Bukkit API
* Now `ReceptacleClickType` can be converted to/from Bukkit ClickType

### Bug Fixes
* Inventories being open twice (at first open) due title update check