### PR TITLE
修复依赖无法下载问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
             )
         }
         version {
-            taboolib = "6.1.1-beta15"
+            taboolib = "6.1.1-beta24"
             coroutines = null
         }
     }


### PR DESCRIPTION
## 依据

[点击查看](https://docs.tabooproject.org/repo_migration)

> 摘要：由于一些历史遗留问题，下载源 ptms.ink:8081 无法使用，自 6.1.1-beta17 起迁移至新的下载源。