### PR TITLE
Feature/receptable

### DIFF
--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/Receptacle.kt
@@ -18,7 +18,7 @@ abstract class Receptacle<Element>(val layout: ReceptacleLayout) {
 
     abstract fun getElement(slot: Int): Element?
     abstract fun hasElement(slot: Int): Boolean
-    abstract fun setElement(element: Element? = null, vararg slots: Int, display: Boolean = true)
+    abstract fun setElement(element: Element? = null, slot: Int, display: Boolean = true)
     abstract fun clear(display: Boolean = true)
     abstract fun refresh(slot: Int = -1)
     abstract fun open(player: Player)
@@ -30,6 +30,10 @@ abstract class Receptacle<Element>(val layout: ReceptacleLayout) {
 
     fun setElement(element: Element?, slots: Collection<Int>, display: Boolean = true) {
         setElement(element, *slots.toIntArray(), display = display)
+    }
+
+    fun setElement(element: Element? = null, vararg slots: Int, display: Boolean = true) {
+        slots.forEach { setElement(element, it, display) }
     }
 
     fun onOpen(handler: (player: Player, receptacle: Receptacle<Element>) -> Unit) {

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
@@ -44,11 +44,10 @@ open class WindowReceptacle(var type: WindowLayout, override var title: String =
         return getElement(slot) != null
     }
 
-    override fun setElement(element: ItemStack?, vararg slots: Int, display: Boolean) {
-        slots.forEach { contents[it] = element }
-        if (display && viewer != null) {
-            slots.forEach { nmsProxy<NMS>().sendWindowsSetSlot(viewer!!, slot = it, itemStack = element, stateId = stateId) }
-        }
+    override fun setElement(element: ItemStack?, slot: Int, display: Boolean) {
+        contents[slot] = element
+        if (!display || viewer == null) return
+        nmsProxy<NMS>().sendWindowsSetSlot(viewer!!, slot = slot, itemStack = element, stateId = stateId)
     }
 
     override fun clear(display: Boolean) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/layout/Layout.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/layout/Layout.kt
@@ -87,6 +87,7 @@ class Layout(
             }
 
             submit(async = false) {
+                Metadata.getMeta(session.viewer)["slot"] = "${event.slot}"
                 session.getIconProperty(event.slot)?.handleClick(event.receptacleClickType, session)
             }
         }


### PR DESCRIPTION
### Additions
-  `meta.slot` context variable on click
- `setElement`  overload for `Receptacle`

Currently, it is not possible to update or perform actions on a single icon slot if it has multiple positions. `meta.slot` would make these interactions manageable.

Overloading `setElement` in `Receptacle` to take a single slot would eliminate unnecessary arrays while iterating through another collection.

### Usage
![Untitled](https://github.com/Dreeam-qwq/TrMenu/assets/48872538/507f6223-bd56-49b4-a978-8476d0e87db4)
