### PR TITLE
feat: Menu internationalization

### DIFF
--- a/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
+++ b/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
@@ -1,5 +1,6 @@
 package trplugins.menu.util.conf
 
+import taboolib.library.configuration.ConfigurationSection
 import taboolib.library.reflex.Reflex.Companion.getProperty
 import taboolib.library.reflex.Reflex.Companion.setProperty
 import taboolib.module.configuration.ConfigSection
@@ -246,31 +247,31 @@ enum class Property(val default: String, val regex: Regex) {
 
     override fun toString(): String = default
 
-    fun ofString(conf: Configuration?, def: String? = null): String {
+    fun ofString(conf: ConfigurationSection?, def: String? = null): String {
         return of(conf, def).toString()
     }
 
-    fun ofBoolean(conf: Configuration?, def: Boolean = false): Boolean {
+    fun ofBoolean(conf: ConfigurationSection?, def: Boolean = false): Boolean {
         return ofString(conf, def.toString()).toBoolean()
     }
 
-    fun ofInt(conf: Configuration?, def: Int = -1): Int {
+    fun ofInt(conf: ConfigurationSection?, def: Int = -1): Int {
         return ofString(conf).toIntOrNull() ?: def
     }
 
-    fun ofList(conf: Configuration?): List<Any> {
+    fun ofList(conf: ConfigurationSection?): List<Any> {
         return asAnyList(of(conf))
     }
 
-    fun ofIntList(conf: Configuration?, def: List<Int> = listOf()): List<Int> {
+    fun ofIntList(conf: ConfigurationSection?, def: List<Int> = listOf()): List<Int> {
         return asIntList(of(conf, def))
     }
 
-    fun ofStringList(conf: Configuration?, def: List<String> = listOf()): List<String> {
+    fun ofStringList(conf: ConfigurationSection?, def: List<String> = listOf()): List<String> {
         return asList(of(conf, def))
     }
 
-    fun ofIconPropertyList(conf: Configuration?, def: List<Property> = listOf()): List<Property> {
+    fun ofIconPropertyList(conf: ConfigurationSection?, def: List<Property> = listOf()): List<Property> {
         val value = of(conf, def)
         if (value !is List<*> && value.toString().equals("true", true)) {
             return listOf(ICON_DISPLAY_NAME, ICON_DISPLAY_LORE)
@@ -288,19 +289,19 @@ enum class Property(val default: String, val regex: Regex) {
         }
     }
 
-    fun ofSection(conf: Configuration?, defKey: String? = null): Configuration? {
+    fun ofSection(conf: ConfigurationSection?, defKey: String? = null): Configuration? {
         return asSection(of(conf), defKey)
     }
 
-    fun ofMap(conf: Configuration?, deep: Boolean = false): Map<String, Any?> {
+    fun ofMap(conf: ConfigurationSection?, deep: Boolean = false): Map<String, Any?> {
         return ofSection(conf)?.getValues(deep) ?: mapOf()
     }
 
-    fun <K, V> ofMap(conf: Configuration?, deep: Boolean = false, keyTransform: (String) -> K = { it as K }, valueTransform: (Any?) -> V = { it as V }): Map<K, V> {
+    fun <K, V> ofMap(conf: ConfigurationSection?, deep: Boolean = false, keyTransform: (String) -> K = { it as K }, valueTransform: (Any?) -> V = { it as V }): Map<K, V> {
         return ofMap(conf, deep).mapKeys { keyTransform(it.key) }.mapValues { valueTransform(it.value) }
     }
 
-    fun ofLists(conf: Configuration?): List<List<String>> {
+    fun ofLists(conf: ConfigurationSection?): List<List<String>> {
         val list = ofList(conf)
         return if (list.firstOrNull() is List<*>) {
             list.map { asList(it) }
@@ -310,11 +311,11 @@ enum class Property(val default: String, val regex: Regex) {
         }
     }
 
-    fun of(conf: Configuration?, def: Any? = null): Any? {
+    fun of(conf: ConfigurationSection?, def: Any? = null): Any? {
         return conf?.get(getKey(conf)) ?: def
     }
 
-    fun getKey(conf: Configuration): String {
+    fun getKey(conf: ConfigurationSection): String {
         return getSectionKey(conf, this)
     }
 
@@ -395,10 +396,10 @@ enum class Property(val default: String, val regex: Regex) {
             return@let null
         }
 
-        fun getSectionKey(section:  Configuration?, property: Property) =
+        fun getSectionKey(section: ConfigurationSection?, property: Property) =
             getSectionKey(section, property.regex, property.default, false)
 
-        fun getSectionKey(section:  Configuration?, regex: Regex, default: String = "", deep: Boolean = false) =
+        fun getSectionKey(section: ConfigurationSection?, regex: Regex, default: String = "", deep: Boolean = false) =
             section?.getKeys(deep)?.firstOrNull { it.matches(regex) } ?: default
 
     }

--- a/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
+++ b/common/src/main/kotlin/trplugins/menu/util/conf/Property.kt
@@ -241,7 +241,12 @@ enum class Property(val default: String, val regex: Regex) {
     /**
      * 菜单内置脚本
      */
-    FUNCTIONS("Functions", "(fun(ction)?|script)s?");
+    FUNCTIONS("Functions", "(fun(ction)?|script)s?"),
+
+    /**
+     * 菜单内置国际化
+     */
+    LANG("Lang", "lang(uage)?|internationalization|i18n");
 
     constructor(default: String, regex: String) : this(default, Regex("(?i)$regex"))
 

--- a/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
@@ -68,6 +68,14 @@ object TrMenu : Plugin() {
     }
 
     private fun onSettingsReload() {
+        Language.default = SETTINGS.getString("Language.Default") ?: "zh_CN"
+        SETTINGS.getConfigurationSection("Language.CodeTransfer")?.also {
+            Language.languageCodeTransfer.clear()
+            it.getKeys(false).forEach { lang ->
+                Language.languageCodeTransfer[lang] = it.getString(lang) ?: Language.default
+            }
+        }
+
         performance = kotlin.runCatching {
             RunningPerformance.valueOf(SETTINGS.getString("Options.Running-Performance") ?: "Normal")
         }.getOrNull() ?: RunningPerformance.NORMAL

--- a/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
@@ -8,12 +8,10 @@ import taboolib.module.configuration.Configuration
 import taboolib.module.kether.Kether
 import taboolib.module.lang.Language
 import taboolib.module.lang.sendLang
-import taboolib.module.nms.nmsProxy
 import taboolib.platform.BukkitPlugin
 import trplugins.menu.api.action.ActionHandle
 import trplugins.menu.api.receptacle.provider.PlatformProvider
 import trplugins.menu.api.receptacle.vanilla.window.NMS
-import trplugins.menu.api.receptacle.vanilla.window.NMSImpl
 import trplugins.menu.module.conf.Loader
 import trplugins.menu.module.conf.prop.RunningPerformance
 import trplugins.menu.module.display.MenuSession
@@ -69,6 +67,7 @@ object TrMenu : Plugin() {
 
     private fun onSettingsReload() {
         Language.default = SETTINGS.getString("Language.Default") ?: "zh_CN"
+        MenuSession.langPlayer = SETTINGS.getString("Language.Player") ?: ""
         SETTINGS.getConfigurationSection("Language.CodeTransfer")?.also {
             Language.languageCodeTransfer.clear()
             it.getKeys(false).forEach { lang ->

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/UpdateLang.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/UpdateLang.kt
@@ -1,0 +1,27 @@
+package trplugins.menu.api.action.impl.menu
+
+import taboolib.common.platform.ProxyPlayer
+import trplugins.menu.api.action.ActionHandle
+import trplugins.menu.api.action.base.ActionBase
+import trplugins.menu.api.action.base.ActionContents
+import trplugins.menu.module.display.MenuSession
+import trplugins.menu.module.display.session
+
+/**
+ * @author Rubenicos
+ * @date 2024/6/14 10:24
+ */
+class UpdateLang(handle: ActionHandle) : ActionBase(handle) {
+
+    override val regex = "update-?lang".toRegex()
+
+    override fun onExecute(contents: ActionContents, player: ProxyPlayer, placeholderPlayer: ProxyPlayer) {
+        val session = player.session()
+        if (MenuSession.langPlayer.isBlank()) {
+            session.locale = player.locale
+        } else {
+            session.locale = session.parse(MenuSession.langPlayer)
+        }
+    }
+
+}

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/send/Lang.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/send/Lang.kt
@@ -1,0 +1,61 @@
+package trplugins.menu.api.action.impl.send
+
+import taboolib.common.platform.ProxyPlayer
+import taboolib.common.util.replaceWithOrder
+import taboolib.module.lang.Type
+import taboolib.module.lang.getLocaleFile
+import trplugins.menu.api.action.ActionHandle;
+import trplugins.menu.api.action.base.ActionBase
+import trplugins.menu.api.action.base.ActionContents
+import trplugins.menu.module.display.session
+import trplugins.menu.util.Regexs
+
+/**
+ * @author Rubenicos
+ * @date 2024/6/10 18:06
+ */
+class Lang(handle: ActionHandle) : ActionBase(handle) {
+
+    override val regex = "((send|tell)-?)lang(-?(message|msg))".toRegex()
+
+    override fun onExecute(contents: ActionContents, player: ProxyPlayer, placeholderPlayer: ProxyPlayer) {
+        val session = player.session()
+        val menu = session.menu
+        val split = contents.stringContent().parseContent(placeholderPlayer).split(' ', limit = 2)
+
+        var node: Type? = menu?.getLocaleNode(session.locale, split[0])
+        if (node == null) {
+            val file = player.getLocaleFile()
+            if (file != null) {
+                node = file.nodes[split[0]]
+            }
+        }
+
+        if (node == null) {
+            player.sendMessage("{" + split[0] + "}")
+        } else if (split.size > 1) {
+            var arguments = split[1]
+            val args: MutableList<String> = ArrayList()
+            if (arguments.contains(' ')) {
+                if (arguments.contains('`')) {
+                    // Replace any "`some text`" with {index} and save value
+                    val replacements = Regexs.SENTENCE.findAll(arguments).mapIndexed { index, result ->
+                        arguments = arguments.replace(result.value, "{$index}")
+                        index to result.groupValues[1].replace("\\s", " ")
+                    }.toMap().values.toTypedArray()
+                    // Split by space and replace any {index} with its respective indexed value
+                    arguments.split(" ").toTypedArray().forEach { s -> args.add(s.replaceWithOrder(*replacements)) }
+                } else {
+                    args.addAll(arguments.split(" "))
+                }
+            } else {
+                args.add(arguments)
+            }
+
+            node.send(player, *args.toTypedArray())
+        } else {
+            node.send(player)
+        }
+    }
+
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -264,9 +264,9 @@ object MenuSerializer : ISerializer {
             var index = 0
             val subs = Property.ICON_SUB_ICONS.ofList(section).map {
                 // i18n
-                val subSectionI18n: Map<String, ConfigurationSection>? = if (iconsI18n == null) null else {
+                val subSectionI18n: Map<String, ConfigurationSection>? = if (sectionI18n == null) null else {
                     val map = mutableMapOf<String, ConfigurationSection>()
-                    iconsI18n.forEach { entry ->
+                    sectionI18n.forEach { entry ->
                         entry.value.getConfigurationSection(index++.toString())?.also { map[entry.key] = it }
                     }
                     if (map.isEmpty()) null else map

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -114,10 +114,7 @@ object MenuSerializer : ISerializer {
         val optionEnableArguments = Property.OPTION_ENABLE_ARGUMENTS.ofBoolean(options, true)
         val optionDefaultArguments = Property.OPTION_DEFAULT_ARGUMENTS.ofStringList(options)
         val optionFreeSlots = Property.OPTION_FREE_SLOTS.ofStringList(conf)
-        val optionDefaultLayout = {
-            val defaultLayout = Property.OPTION_DEFAULT_LAYOUT.ofString(options, "0")
-            defaultLayout.toIntOrNull() ?: defaultLayout
-        }
+        val optionDefaultLayout = Property.OPTION_DEFAULT_LAYOUT.ofString(options, "0")
         val optionHidePlayerInventory = Property.OPTION_HIDE_PLAYER_INVENTORY.ofBoolean(options, false)
 //        val optionHidePurePacket = Property.OPTION_PURE_PACKET.ofBoolean(options, true)
         val optionMinClickDelay = Property.OPTION_MIN_CLICK_DELAY.ofInt(options, 200)
@@ -135,7 +132,7 @@ object MenuSerializer : ISerializer {
             optionEnableArguments,
             optionDefaultArguments.toTypedArray(),
             optionFreeSlots.flatMap { Position.Slot.readStaticSlots(it) }.toSet(),
-            optionDefaultLayout,
+            optionDefaultLayout.toIntOrNull() ?: optionDefaultLayout,
             optionDependExpansions.toTypedArray(),
             optionMinClickDelay,
             optionHidePlayerInventory,

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -66,7 +66,8 @@ object MenuSerializer : ISerializer {
         // 加载菜单配置
         val conf = Configuration.loadFromFile(file, type)
 
-        val languages: Set<String> = conf.getConfigurationSection("Lang")?.getKeys(false) ?: emptySet()
+        val langKey = Property.LANG.getKey(conf)
+        val languages: Set<String> = conf.getConfigurationSection(langKey)?.getKeys(false) ?: emptySet()
 
         // 读取菜单设置
         val settings = serializeSetting(conf, languages)
@@ -89,7 +90,7 @@ object MenuSerializer : ISerializer {
             }
         }
         // 返回菜单
-        Menu(id, settings.result as MenuSettings, layout.result as MenuLayout, icons.asIcons(), conf).also {
+        Menu(id, settings.result as MenuSettings, layout.result as MenuLayout, icons.asIcons(), conf, langKey).also {
             result.result = it
             return result
         }

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -357,6 +357,12 @@ object MenuSerializer : ISerializer {
             )
 
             // i18n
+            if (def != null && inherit.contains(Property.ICON_DISPLAY_NAME) && name.isEmpty()) {
+                item.nameI18n.putAll(def.display.nameI18n)
+            }
+            if (def != null && inherit.contains(Property.ICON_DISPLAY_LORE) && lore.isEmpty()) {
+                item.loreI18n.putAll(def.display.loreI18n)
+            }
             sectionI18n?.forEach { (locale, conf) ->
                 val nameI18n = Property.ICON_DISPLAY_NAME.ofStringList(conf)
                 if (nameI18n.isNotEmpty()) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player
 import taboolib.common.platform.function.adaptPlayer
 import taboolib.common.platform.function.pluginId
 import taboolib.common.platform.function.submit
+import taboolib.library.configuration.ConfigurationSection
 import taboolib.module.configuration.Configuration
 import taboolib.platform.util.cancelNextChat
 import trplugins.menu.api.event.MenuOpenEvent
@@ -25,7 +26,8 @@ class Menu(
     val settings: MenuSettings,
     val layout: MenuLayout,
     val icons: Set<Icon>,
-    conf: Configuration
+    conf: Configuration,
+    private val langKey: String? = null,
 ) {
 
     companion object {
@@ -190,6 +192,13 @@ class Menu(
 
     fun getIcon(id: String): Icon? {
         return icons.find { it.id == id }
+    }
+
+    fun getLocaleSection(locale: String): ConfigurationSection? {
+        if (langKey == null) {
+            return null
+        }
+        return conf.getConfigurationSection("$langKey.$locale") ?: conf.getConfigurationSection("$langKey.default")
     }
 
     private fun forViewers(block: (Player) -> Unit) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -140,13 +140,14 @@ class Menu(
      * 加载容器标题 & 自动更新
      */
     private fun loadTitle(session: MenuSession) {
-        session.receptacle?.title(settings.title.next(session.id)?.let { session.parse(it) } ?: pluginId, update = false)
+        val title = settings.title(session)
+        session.receptacle?.title(title.next(session.id)?.let { session.parse(it) } ?: pluginId, update = false)
         
         val setTitle = {
-            session.receptacle?.title(settings.title.next(session.id)?.let { session.parse(it) } ?: pluginId)
+            session.receptacle?.title(title.next(session.id)?.let { session.parse(it) } ?: pluginId)
         }
 
-        if (settings.titleUpdate > 0 && settings.title.cyclable()) {
+        if (settings.titleUpdate > 0 && title.cyclable()) {
             session.arrange(submit(delay = 10, period = settings.titleUpdate.toLong(), async = true) {
                 setTitle()
             })

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -5,8 +5,8 @@ import org.bukkit.entity.Player
 import taboolib.common.platform.function.adaptPlayer
 import taboolib.common.platform.function.pluginId
 import taboolib.common.platform.function.submit
-import taboolib.library.configuration.ConfigurationSection
 import taboolib.module.configuration.Configuration
+import taboolib.module.lang.Type
 import taboolib.platform.util.cancelNextChat
 import trplugins.menu.api.event.MenuOpenEvent
 import trplugins.menu.api.event.MenuPageChangeEvent
@@ -194,11 +194,15 @@ class Menu(
         return icons.find { it.id == id }
     }
 
-    fun getLocaleSection(locale: String): ConfigurationSection? {
+    fun getLocaleValue(locale: String, key: String): Any? {
         if (langKey == null) {
             return null
         }
-        return conf.getConfigurationSection("$langKey.$locale") ?: conf.getConfigurationSection("$langKey.default")
+        return conf.getConfigurationSection("$langKey.$locale")?.let { provided ->
+            provided.getKeys(true).find { it.equals(key, ignoreCase = true) }?.let { provided[it] }
+        } ?: conf.getConfigurationSection("$langKey.default")?.let { default ->
+            default.getKeys(true).find { it.equals(key, ignoreCase = true) }?.let { default[it] }
+        }
     }
 
     private fun forViewers(block: (Player) -> Unit) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -28,6 +28,7 @@ class Menu(
     val icons: Set<Icon>,
     conf: Configuration,
     private val langKey: String? = null,
+    lang: Map<String, HashMap<String, Type>>? = null
 ) {
 
     companion object {
@@ -37,6 +38,9 @@ class Menu(
     }
 
     var conf: Configuration = conf
+        internal set
+
+    var lang: Map<String, HashMap<String, Type>>? = lang
         internal set
 
     val viewers: MutableSet<String> = mutableSetOf()
@@ -192,6 +196,17 @@ class Menu(
 
     fun getIcon(id: String): Icon? {
         return icons.find { it.id == id }
+    }
+
+    fun getLocaleNode(locale: String, key: String): Type? {
+        if (lang == null) {
+            return null
+        }
+        return lang?.get(locale)?.let { provided ->
+            provided[key]
+        } ?: lang?.get("default")?.let { default ->
+            default[key]
+        }
     }
 
     fun getLocaleValue(locale: String, key: String): Any? {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
@@ -165,8 +165,9 @@ class MenuSession(
             }
             if (arguments != null) {
                 value.replaceWithOrder(*arguments)
+            } else {
+                value
             }
-            value
         }
     }
 

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
@@ -2,9 +2,10 @@ package trplugins.menu.module.display
 
 import org.bukkit.entity.Player
 import taboolib.common.platform.ProxyPlayer
+import taboolib.common.platform.function.submit
+import taboolib.common.platform.function.submitAsync
 import taboolib.common.platform.service.PlatformExecutor
 import taboolib.common.util.replaceWithOrder
-import taboolib.library.configuration.ConfigurationSection
 import taboolib.library.reflex.Reflex.Companion.getProperty
 import taboolib.module.chat.colored
 import taboolib.module.lang.Language
@@ -87,6 +88,13 @@ class MenuSession(
     private val temporaries = mutableSetOf<PlatformExecutor.PlatformTask>()
 
     var locale: String = kotlin.run {
+        if (langPlayer.isNotBlank()) {
+            // Avoid ConcurrentModificationException
+            submitAsync(delay = 2L) {
+                locale = parse(langPlayer)
+            }
+        }
+
         val code = try {
             viewer.locale
         } catch (ignored: NoSuchMethodError) {
@@ -102,7 +110,7 @@ class MenuSession(
                 icon.defIcon.display.cache.remove(id)
                 icon.subs.elements.forEach { sub -> sub.display.cache.remove(id) }
             } }
-            field = value.lowercase()
+            field = Language.languageCodeTransfer[value.lowercase()]?.lowercase() ?: value.lowercase()
         }
 
     /**
@@ -289,6 +297,7 @@ class MenuSession(
 
         @JvmField
         val SESSIONS = mutableMapOf<UUID, MenuSession>()
+        var langPlayer: String = ""
 
         fun getSession(player: Player): MenuSession {
             return SESSIONS.computeIfAbsent(player.uniqueId) { MenuSession(player, null, 0, arrayOf()) }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
@@ -4,7 +4,9 @@ import org.bukkit.entity.Player
 import taboolib.common.platform.ProxyPlayer
 import taboolib.common.platform.service.PlatformExecutor
 import taboolib.common.util.replaceWithOrder
+import taboolib.library.reflex.Reflex.Companion.getProperty
 import taboolib.module.chat.colored
+import taboolib.module.lang.Language
 import taboolib.platform.compat.replacePlaceholder
 import trplugins.menu.api.event.MenuCloseEvent
 import trplugins.menu.api.receptacle.vanilla.window.WindowReceptacle
@@ -84,6 +86,16 @@ class MenuSession(
     // 临时任务（切换页码时允许删除）
     private val temporaries = mutableSetOf<PlatformExecutor.PlatformTask>()
 
+    val locale: String
+        get() = kotlin.run {
+            val code = try {
+                viewer.locale
+            } catch (ignored: NoSuchMethodError) {
+                viewer.getProperty<String>("entity/locale")!!
+            }.lowercase()
+            
+            Language.languageCodeTransfer[code]?.lowercase() ?: code
+        }
 
     /**
      * 取得当前会话的布局
@@ -106,7 +118,13 @@ class MenuSession(
         val preColor = MenuSettings.PRE_COLOR
         val funced = FunctionParser.parse(placeholderPlayer, string) { type, value ->
             when (type) {
-                "node", "nodes", "n" -> menu?.conf?.get(parse(menu!!.conf.ignoreCase(value))).toString()
+                "node", "nodes", "n" -> menu?.conf?.get(parse(menu!!.conf.ignoreCase(value))).let {
+                    if (it is List<*>) {
+                        it.joinToString("\n")
+                    } else {
+                        it.toString()
+                    }
+                }
                 else -> null
             }
         }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
@@ -86,15 +86,23 @@ class MenuSession(
     // 临时任务（切换页码时允许删除）
     private val temporaries = mutableSetOf<PlatformExecutor.PlatformTask>()
 
-    val locale: String
-        get() = kotlin.run {
-            val code = try {
-                viewer.locale
-            } catch (ignored: NoSuchMethodError) {
-                viewer.getProperty<String>("entity/locale")!!
-            }.lowercase()
-            
-            Language.languageCodeTransfer[code]?.lowercase() ?: code
+    var locale: String = kotlin.run {
+        val code = try {
+            viewer.locale
+        } catch (ignored: NoSuchMethodError) {
+            viewer.getProperty<String>("entity/locale")!!
+        }.lowercase()
+
+        Language.languageCodeTransfer[code]?.lowercase() ?: code
+    }
+        set(value) {
+            if (field == value.lowercase()) return
+            // Clear display cache
+            Menu.menus.forEach { menu -> menu.icons.forEach { icon ->
+                icon.defIcon.display.cache.remove(id)
+                icon.subs.elements.forEach { sub -> sub.display.cache.remove(id) }
+            } }
+            field = value.lowercase()
         }
 
     /**

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSession.kt
@@ -127,6 +127,7 @@ class MenuSession(
         val funced = FunctionParser.parse(placeholderPlayer, string) { type, value ->
             when (type) {
                 "node", "nodes", "n" -> parseNode(menu?.conf, value)
+                "lang" -> parseNode(menu?.getLocaleSection(locale), value)
                 else -> null
             }
         }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
@@ -56,6 +56,19 @@ class MenuSettings(
             }
         }
 
+    private val titleI18n = HashMap<String, CycleList<String>>()
+
+    fun addI18nTitle(locale: String, title: CycleList<String>) {
+        titleI18n[locale] = title
+    }
+
+    fun title(session: MenuSession): CycleList<String> {
+        if (titleI18n.isEmpty()) {
+            return title
+        }
+        return titleI18n[session.locale] ?: title
+    }
+
     /**
      * 匹配菜单绑定的命令
      *

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/icon/IconProperty.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/icon/IconProperty.kt
@@ -22,12 +22,12 @@ class IconProperty(
         return display.meta.isDynamic || display.texture.cyclable() || display.texture.elements.any { it.dynamic }
     }
 
-    fun isNameUpdatable(): Boolean {
-        return display.name.cyclable() || display.name.elements.any { Regexs.containsPlaceholder(it) }
+    fun isNameUpdatable(session: MenuSession): Boolean {
+        return display.name(session).cyclable() || display.name(session).elements.any { Regexs.containsPlaceholder(it) }
     }
 
-    fun isLoreUpdatable(): Boolean {
-        return display.lore.cyclable() || display.lore.elements.any { it -> Regexs.containsPlaceholder(it.lore.joinToString(" ") { it.first }) }
+    fun isLoreUpdatable(session: MenuSession): Boolean {
+        return display.lore(session).cyclable() || display.lore(session).elements.any { it -> Regexs.containsPlaceholder(it.lore.joinToString(" ") { it.first }) }
     }
 
     fun handleClick(type: ReceptacleClickType, session: MenuSession) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/item/Item.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/item/Item.kt
@@ -14,19 +14,45 @@ import trplugins.menu.util.collections.CycleList
  * @author Arasple
  * @date 2021/1/25 10:48
  */
-class Item(
+open class Item(
     val texture: CycleList<Texture>,
     val name: CycleList<String>,
     val lore: CycleList<Lore>,
     val meta: Meta
 ) : IItem {
 
+    private val nameI18n = HashMap<String, CycleList<String>>()
+
+    private val loreI18n = HashMap<String, CycleList<Lore>>()
+
     internal val cache = mutableMapOf<Int, ItemStack>()
 
-    private fun name(session: MenuSession) = this.name.current(session.id)?.let { defColorize(session.parse(it)) }
+    fun addI18nName(locale: String, name: CycleList<String>) {
+        nameI18n[locale] = name
+    }
 
-    private fun lore(session: MenuSession) =
-        this.lore.current(session.id)?.parse(session)?.map { defColorize(it, true) }
+    fun addI18nLore(locale: String, lore: CycleList<Lore>) {
+        loreI18n[locale] = lore
+    }
+
+    fun name(session: MenuSession): CycleList<String> {
+        if (nameI18n.isEmpty()) {
+            return name
+        }
+        return nameI18n[session.locale] ?: name
+    }
+
+    fun lore(session: MenuSession): CycleList<Lore> {
+        if (loreI18n.isEmpty()) {
+            return lore
+        }
+        return loreI18n[session.locale] ?: lore
+    }
+
+    private fun parsedName(session: MenuSession) = name(session).current(session.id)?.let { defColorize(session.parse(it)) }
+
+    private fun parsedLore(session: MenuSession) =
+        lore(session).current(session.id)?.parse(session)?.map { defColorize(it, true) }
 
     fun get(session: MenuSession): ItemStack {
         return if (cache.containsKey(session.id)) cache[session.id]!!
@@ -66,8 +92,8 @@ class Item(
 
     private fun build(
         session: MenuSession,
-        name: String? = name(session),
-        lore: List<String>? = lore(session)
+        name: String? = parsedName(session),
+        lore: List<String>? = parsedLore(session)
     ): ItemStack {
         val item = generate(session, texture.current(session.id)!!, name, lore, meta)
         cache[session.id] = item
@@ -88,14 +114,14 @@ class Item(
     }
 
     override fun updateName(session: MenuSession) {
-        name.cycleIndex(session.id)
+        name(session).cycleIndex(session.id)
 
         if (!cache.containsKey(session.id))
             build(session)
         else {
             val current = cache[session.id]
             try {
-                val new = buildItem(current!!) { name = name(session) }
+                val new = buildItem(current!!) { name = parsedName(session) }
                 cache[session.id] = new
             } catch (t: Throwable) {
                 t.stackTrace
@@ -104,7 +130,7 @@ class Item(
     }
 
     override fun updateLore(session: MenuSession) {
-        lore.cycleIndex(session.id)
+        lore(session).cycleIndex(session.id)
 
         if (!cache.containsKey(session.id)) {
             build(session)
@@ -113,7 +139,7 @@ class Item(
             if (current != null && current.type != Material.AIR) {
                 val new = buildItem(current) {
                     lore.clear()
-                    lore.addAll(lore(session) ?: listOf())
+                    lore.addAll(parsedLore(session) ?: listOf())
                 }
                 cache[session.id] = new
             }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/item/Item.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/item/Item.kt
@@ -21,9 +21,9 @@ open class Item(
     val meta: Meta
 ) : IItem {
 
-    private val nameI18n = HashMap<String, CycleList<String>>()
+    val nameI18n = HashMap<String, CycleList<String>>()
 
-    private val loreI18n = HashMap<String, CycleList<Lore>>()
+    val loreI18n = HashMap<String, CycleList<Lore>>()
 
     internal val cache = mutableMapOf<Int, ItemStack>()
 

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/command/impl/CommandDebug.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/command/impl/CommandDebug.kt
@@ -171,7 +171,7 @@ object CommandDebug : CommandExpression {
                     &6HidePINV: ${menu.settings.hidePlayerInventory}
                     &6Bounds: ${menu.settings.boundCommands.joinToString(", ")} / ${menu.settings.boundItems.contentToString()}
                 &eIcons:
-                    ${menu.icons.joinToString { "&7[ &f${it.id} &7] &8${it.update} ;" }}
+                    ${menu.icons.joinToString { "&7[ &f${it.id} &7];" }}
                     
                 &a&l「&8--------------------------------------------------&a&l」
             """.trimIndent().split("\n")

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/ext/HookPlaceholderAPI.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/ext/HookPlaceholderAPI.kt
@@ -38,6 +38,7 @@ object HookPlaceholderAPI : PlaceholderExpansion {
                 "globaldata" -> runCatching { Metadata.globalData[value()].toString() }.getOrElse { "null" }
                 "node" -> session.menu?.conf?.let { it[it.ignoreCase(value())].toString() }.toString()
                 "menu" -> menu(session, args)
+                "locale" -> session.locale
                 "js" -> if (enabledParseJavaScript) if (args.size > 1) JavaScriptAgent.eval(session, args[1]).asString() else "" else "UNABLE_PARSE"
                 else -> ""
             } }.getOrNull().toString()

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/ext/HookPlaceholderAPI.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/ext/HookPlaceholderAPI.kt
@@ -52,7 +52,7 @@ object HookPlaceholderAPI : PlaceholderExpansion {
             "pages" -> session.menu?.layout?.layouts?.size.toString()
             "next" -> (session.page + 1).toString()
             "prev" -> (session.page - 1).toString()
-            "title" -> session.menu?.settings?.title?.get(session.id).toString()
+            "title" -> session.menu?.settings?.title(session)?.get(session.id).toString()
             else -> ""
         }
     }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
@@ -1,0 +1,18 @@
+package trplugins.menu.module.internal.listener
+
+import org.bukkit.event.player.PlayerLocaleChangeEvent
+import taboolib.common.platform.event.SubscribeEvent
+import trplugins.menu.module.display.session
+
+/**
+ * @author Rubenicos
+ * @date 2024/5/29 15:03
+ */
+object ListenerLocale {
+
+    @SubscribeEvent
+    fun onLocaleChange(e: PlayerLocaleChangeEvent) {
+        e.player.session().locale = e.locale
+    }
+
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
@@ -2,6 +2,7 @@ package trplugins.menu.module.internal.listener
 
 import org.bukkit.event.player.PlayerLocaleChangeEvent
 import taboolib.common.platform.event.SubscribeEvent
+import trplugins.menu.module.display.MenuSession
 import trplugins.menu.module.display.session
 
 /**
@@ -12,7 +13,9 @@ object ListenerLocale {
 
     @SubscribeEvent
     fun onLocaleChange(e: PlayerLocaleChangeEvent) {
-        e.player.session().locale = e.locale
+        if (MenuSession.langPlayer.isBlank()) {
+            e.player.session().locale = e.locale
+        }
     }
 
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
@@ -37,7 +37,7 @@ object FunctionParser {
                         "meta", "m" -> Metadata.getMeta(player)[value].toString()
                         "data", "d" -> Metadata.getData(player)[value].toString()
                         "globaldata", "gdata", "g" -> runCatching { Metadata.globalData[value].toString() }.getOrElse { "null" }
-                        "lang", "triton" -> parseLangText(player, value)
+                        "triton" -> parseLangText(player, value)
 
                         else -> block(type, value) ?: "{${it.value}}"
                     }

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -14,6 +14,9 @@ Options:
 
 Language:
   Default: 'zh_CN'
+  # Parse the provided text as player language
+  # Leave it blank to use player locale instead
+  Player: ''
   CodeTransfer:
     zh_hans_cn: 'zh_CN'
     zh_hant_cn: 'zh_TW'

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -12,6 +12,16 @@ Options:
   Placeholders:
     JavaScript-Parse: false
 
+Language:
+  Default: 'zh_CN'
+  CodeTransfer:
+    zh_hans_cn: 'zh_CN'
+    zh_hant_cn: 'zh_TW'
+    en_ca: 'en_US'
+    en_au: 'en_US'
+    en_gb: 'en_US'
+    en_nz: 'en_US'
+
 Database:
   # Local: SQLITE
   # External: SQL, MONGODB


### PR DESCRIPTION
## Internationalization

### Plugin settings
First of all, there's a new option on settings.yml to configure plugin default languaje and also code transfers:
```yaml
Language:
  Default: 'zh_CN'
  # Parse the provided text as player language
  # Leave it blank to use player locale instead
  Player: ''
  CodeTransfer:
    zh_hans_cn: 'zh_CN'
    zh_hant_cn: 'zh_TW'
    en_ca: 'en_US'
    en_au: 'en_US'
    en_gb: 'en_US'
    en_nz: 'en_US'
```

### Parseable player lang
Using a parseable string you can make a persistent selected locale.
```yaml
# settings.yml
Language:
  Player: '${js:data.getOrDefault("player.lang", vars("%player_locale%"))}'
```
And also update with `update-lang` action when data has changed.
```yaml
Title: 'Select Lang'

Layout:
  - 'ABC      '

Buttons:
  'A':
    display:
      mat: DIAMOND
      name: 'English'
    actions:
      all:
        - 'set-data: player.lang en_us'
        - 'update-lang'
  'B':
    display:
      mat: DIAMOND
      name: 'Español'
    actions:
      all:
        - 'set-data: player.lang es_es'
        - 'update-lang'
  'C':
    display:
      mat: BARRIER
      name: 'Default'
    actions:
      all:
        - 'remove-data: player.lang'
        - 'update-lang'
```

### Menu configuration
Added "Lang" section to menu configuration to configure into different languages any displayed text as:
* Title
* Display name
* Display lore

For example:
```yaml
Lang:
  es_es:
    Title: '&6Español'
    Buttons:
      'A':
        name: '&eTexto en español'
        lore:
          - ' '
          - '&7Algún texto'
        # "0" means the first conditional icon
        '0':
          name: '&eOtro texto'
  fr_fr:
    Title: '&6Français'

Title: '&6English'

Layout:
  - '    A    '

Buttons:
  'A':
    display:
      mat: DIAMOND
      name: '&eText on english'
      lore:
        - ' '
        - '&7Some text'
    icons:
      - condition: 'perm *perm.test'
        display:
          name: '&eOther text'
```

### Language node parser
Using `{lang:<path>_[arguments]}` you can get a language node using current locale.
If there is no path for player locale, the default locale will be used instead.
```yaml
Lang:
  # Default language configuration
  default:
    Some:
      Key: '&6This is a single string'
      List:
        - '&7This a list of strings'
        - '&7with arguments: {0} {1}'
  es_es:
    Some:
      Key: '&6Esto es un texto simple'
      List:
        - '&7Esta es una lista de texto'
        - '&7con argumentos: {0} {1}'

Title: '&6Example'

Layout:
  - '    A    '

Buttons:
  'A':
    display:
      mat: DIAMOND
      name: '&cTesting'
      lore:
        - '&7Text: {lang:Some.Key}'
        - '&7List:'
        - '{lang:Some.List_arg1_arg2}'
```

### Language action
Using `lang: <path> [arguments...]` you can send a language display type loaded from menu configuration.
This one was a bit tricky due there are multiple display types, so them need to be parsed by its respective type.
I resolved by it by using Taboolib code (and also add license information) with a few edits to allow tree-like paths for language display types.
If the display path doesn't exist on menu configuration, it will be taken from TrMenu language files.
Instead of language node this action **is not case insensitive**, any path must be specified as its configuration
```yaml
Lang:
  # Default language configuration
  default:
    Some:
      Message:
        - '&eHello {0}, this is a localized message'
        - '&ewith multiple lines {1}'
  es_es:
    Some:
      Message:
        - '&eHola {0}, este es un mensaje traducido'
        - '&econ múltiples lineas {2}'

Title: '&6Example'

Layout:
  - '    A    '

Buttons:
  'A':
    display:
      mat: DIAMOND
      name: '&cClick here'
    actions:
      all:
        - 'lang: Some.Message %player_name% `argument with spaces`'
        - 'close'
```

### How this is useful?
I been using TrMenu for years and making every menu compatible with multiple languages
Some days ago I started a complety rework of every menu in one of my server modes and found that is faster and easier to make TrMenu distribute every translated text automatically instead of making hundreds of conditional icons
So, it's useful to maintain a server compatible with players in different regions

### TODO
- [x] Add `send-lang: <path> [default text]` action to send translated text to player
- [x] Retreive player locale from database (To make a persistent selected locale)
- [x] Replace `{lang:node}` with built-in lang configuration (Or add a new menu option to set a "lang provider")
- [x] Do more menu testing
- [x] Apply any player locale change automatically

Any suggestion?