### PR TITLE
Fix ghost items when using movable click types

### DIFF
--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/ReceptacleInteractEvent.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/ReceptacleInteractEvent.kt
@@ -15,9 +15,7 @@ class ReceptacleInteractEvent<Element>(val player: Player, val receptacle: Recep
 
     fun refresh() {
         if (receptacleClickType.isItemMoveable()) {
-            receptacle.layout.hotBarSlots.forEach { receptacle.refresh(it) }
-            receptacle.layout.mainInvSlots.forEach { receptacle.refresh(it) }
-            receptacle.layout.containerSlots.forEach { receptacle.refresh(it) }
+            receptacle.refresh()
         } else {
             receptacle.refresh(slot)
         }


### PR DESCRIPTION
`ReceptacleInteractEvent#refresh` calls `Receptacle#refresh` multiple times with a specific slot if it is a movable click type. This causes it to call `WindowReceptacle#setupPlayerInventorySlots` repeatedly. Using `Receptacle#refresh` with the default slot -1 will only call it once and will handle hotbar slots correctly

![Screen Recording 2024-06-07 at 12 31 25 AM](https://github.com/Dreeam-qwq/TrMenu/assets/48872538/53a89d5f-d31f-4910-a8f5-e33b3c4583e9)
