### PR TITLE
Fix title clearing on page change

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/Page.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/Page.kt
@@ -22,9 +22,10 @@ class Page(handle: ActionHandle) : ActionBase(handle) {
     override fun onExecute(contents: ActionContents, player: ProxyPlayer, placeholderPlayer: ProxyPlayer) {
         val session = player.session()
         val menu = session.menu ?: return
-        val page = min(contents.stringContent().parseContent(placeholderPlayer).toIntOrNull() ?: 0, menu.layout.getSize() - 1)
+        val split = contents.stringContent().parseContent(placeholderPlayer).split(' ', limit = 2)
+        val page = min(split[0].toIntOrNull() ?: 0, menu.layout.getSize() - 1)
 
-        menu.page(player.cast(), max(0, page))
+        menu.page(player.cast(), max(0, page), if (split.size > 1) split[1] else null)
     }
 
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -112,13 +112,13 @@ class Menu(
     /**
      * 本菜单内切换页码
      */
-    fun page(viewer: Player, page: Int) {
+    fun page(viewer: Player, page: Int, title: String? = null) {
         if (page < 0 || page > layout.getSize()) return
         val session = MenuSession.getSession(viewer)
         val previous = session.layout()!!
         val layout = layout[page]
         val receptacle: WindowReceptacle
-        val override = previous.isSimilar(layout) && session.receptacle != null
+        val override = previous.isSimilar(layout) && session.receptacle != null && title == null
 
         val menuPageChangeEvent = MenuPageChangeEvent(session, session.page, page, override)
         menuPageChangeEvent.call()
@@ -139,7 +139,16 @@ class Menu(
         if (override) {
             receptacle.refresh()
             session.updateActiveSlots()
-        } else receptacle.open(viewer)
+        } else {
+            if (title == null) {
+                if (!settings.title(session).cyclable()) {
+                    loadTitle(session)
+                }
+            } else {
+                session.receptacle?.title(title, update = false)
+            }
+            receptacle.open(viewer)
+        }
     }
 
     /**


### PR DESCRIPTION
### Additions
* Now `page` action can be specified as `page: <number> [title]` to change page and set a new title at the same time, this will reduce the amount of sended packets and also fix some menu updates for bedrock players and people emulating Java Edition on android devices.

### Bug Fixes
* Fix title clearing on page change, when page has a different size.