### PR TITLE
Make reaction eval by iterator

### DIFF
--- a/api/action/src/main/kotlin/trplugins/menu/api/action/ActionHandle.kt
+++ b/api/action/src/main/kotlin/trplugins/menu/api/action/ActionHandle.kt
@@ -72,20 +72,28 @@ class ActionHandle(
     }
 
     fun runAction(player: ProxyPlayer, actions: List<ActionEntry>): Boolean {
+        return runAction(player, actions.iterator())
+    }
+
+    fun runAction(player: ProxyPlayer, actions: Iterator<ActionEntry>): Boolean {
         val run = mutableListOf<ActionEntry>()
         var result = true
         var delay = 0L
 
         run filter@{
-            actions.filter { it.option.evalChance() }.forEach {
+            while (actions.hasNext()) {
+                val action = actions.next()
+                if (!action.option.evalChance()) {
+                    continue
+                }
                 when {
-                    it.base is Break && it.option.evalCondition(player) -> {
+                    action.base is Break && action.option.evalCondition(player) -> {
                         result = false
                         return@filter
                     }
-                    it.base is Delay -> delay += it.base.getDelay(player, it.contents.stringContent())
-                    delay > 0 -> submit(delay = delay) { it.execute(player) }
-                    else -> run.add(it)
+                    action.base is Delay -> delay += action.base.getDelay(player, action.contents.stringContent())
+                    delay > 0 -> submit(delay = delay) { action.execute(player) }
+                    else -> run.add(action)
                 }
             }
         }

--- a/api/action/src/main/kotlin/trplugins/menu/api/reaction/ConditionalReaction.kt
+++ b/api/action/src/main/kotlin/trplugins/menu/api/reaction/ConditionalReaction.kt
@@ -21,9 +21,9 @@ class ConditionalReaction(handle: ActionHandle,
         return accept.isEmpty() && deny.isEmpty()
     }
 
-    override fun getActions(player: ProxyPlayer): List<ActionEntry> {
-        return if (evalCondition(player)) accept.getActions(player)
-        else deny.getActions(player)
+    override fun getIterator(player: ProxyPlayer): Iterator<ActionEntry> {
+        return if (evalCondition(player)) accept.getIterator(player)
+        else deny.getIterator(player)
     }
 
     private fun evalCondition(player: ProxyPlayer): Boolean {

--- a/api/action/src/main/kotlin/trplugins/menu/api/reaction/Reaction.kt
+++ b/api/action/src/main/kotlin/trplugins/menu/api/reaction/Reaction.kt
@@ -13,7 +13,7 @@ abstract class Reaction(val handle: ActionHandle, var priority: Int) {
 
     abstract fun isEmpty(): Boolean
 
-    abstract fun getActions(player: ProxyPlayer): List<ActionEntry>
+    abstract fun getIterator(player: ProxyPlayer): Iterator<ActionEntry>
 
     companion object {
         fun of(handle: ActionHandle, priority: Int, any: Any): Reaction? {

--- a/api/action/src/main/kotlin/trplugins/menu/api/reaction/SingleReaction.kt
+++ b/api/action/src/main/kotlin/trplugins/menu/api/reaction/SingleReaction.kt
@@ -18,7 +18,7 @@ class SingleReaction(
         return actions.isEmpty()
     }
 
-    override fun getActions(player: ProxyPlayer): List<ActionEntry> {
-        return actions
+    override fun getIterator(player: ProxyPlayer): Iterator<ActionEntry> {
+        return actions.iterator()
     }
 }


### PR DESCRIPTION
TrMenu check all conditional actions and ignoring any `break` action inside until execution.
With this change, TrMenu will check conditional actions while execution is running to match them with actual execution process.
### Before
```yaml
- 'tell: &eHello'
- 'break<require:perm *some.perm>' # This condition is checked on execution process
- condition: 'perm *other.perm' # This condition was checked before execution
  actions:
    - 'break'
- condition: 'perm *test.perm' # This condition was checked before execution ignoring above condition
  actions:
    - 'break'
- 'tell: &eBye'
```

### After
```yaml
- 'tell: &eHello'
- 'break<require:perm *some.perm>' # This condition is checked on execution process
- condition: 'perm *other.perm' # This condition is checked on execution process
  actions:
    - 'break'
- condition: 'perm *test.perm' # This condition is checked on execution process
  actions:
    - 'break'
- 'tell: &eBye'
```