### PR TITLE
Some fixes and more item edit actions

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
@@ -61,9 +61,16 @@ object Metadata {
 
     fun pushData(player: Player, dataMap: DataMap = getData(player)) {
         getLocalePlayer(player).let {
-            if (it != null)
+            if (it != null) {
+                it.getConfigurationSection("TrMenu.Data")?.getKeys(true)?.forEach { key ->
+                    if (!dataMap.data.containsKey(key)) {
+                        it["TrMenu.Data.$key"] = null
+                    }
+                }
                 dataMap.data.forEach { (key, value) -> it["TrMenu.Data.$key"] = value }
-            else println("NullData: ${player.name}")
+            } else {
+                println("NullData: ${player.name}")
+            }
         }
         database.push(player)
     }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/database/DatabaseSQL.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/database/DatabaseSQL.kt
@@ -46,19 +46,30 @@ class DatabaseSQL : Database() {
 
     override fun push(player: Player, indexPlayer: String) {
         val file = cache[indexPlayer] ?: return
+        val str = file.saveToString()
         if (table.workspace(dataSource) { select { where { "user" eq indexPlayer } } }.find()) {
-            table.workspace(dataSource) {
-                update {
-                    set("data", file.saveToString())
-                    where {
-                        "user" eq indexPlayer
+            if (str.isBlank()) {
+                table.workspace(dataSource) {
+                    delete {
+                        where {
+                            "user" eq indexPlayer
+                        }
                     }
-                }
-            }.run()
-        } else {
+                }.run()
+            } else {
+                table.workspace(dataSource) {
+                    update {
+                        set("data", str)
+                        where {
+                            "user" eq indexPlayer
+                        }
+                    }
+                }.run()
+            }
+        } else if (str.isNotBlank()) {
             table.workspace(dataSource) {
                 insert("user", "data") {
-                    value(indexPlayer, file.saveToString())
+                    value(indexPlayer, str)
                 }
             }.run()
         }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/database/DatabaseSQLite.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/database/DatabaseSQLite.kt
@@ -62,19 +62,30 @@ class DatabaseSQLite : Database() {
 
     override fun push(player: Player, indexPlayer: String) {
         val file = cache[indexPlayer] ?: return
+        val str = file.saveToString()
         if (table.workspace(dataSource) { select { where { "user" eq indexPlayer } } }.find()) {
-            table.workspace(dataSource) {
-                update {
-                    set("data", file.saveToString())
-                    where {
-                        "user" eq indexPlayer
+            if (str.isBlank()) {
+                table.workspace(dataSource) {
+                    delete {
+                        where {
+                            "user" eq indexPlayer
+                        }
                     }
-                }
-            }.run()
-        } else {
+                }.run()
+            } else {
+                table.workspace(dataSource) {
+                    update {
+                        set("data", str)
+                        where {
+                            "user" eq indexPlayer
+                        }
+                    }
+                }.run()
+            }
+        } else if (str.isNotBlank()) {
             table.workspace(dataSource) {
                 insert("user", "data") {
-                    value(indexPlayer, file.saveToString())
+                    value(indexPlayer, str)
                 }
             }.run()
         }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerLocale.kt
@@ -1,7 +1,9 @@
 package trplugins.menu.module.internal.listener
 
 import org.bukkit.event.player.PlayerLocaleChangeEvent
+import taboolib.common.platform.event.OptionalEvent
 import taboolib.common.platform.event.SubscribeEvent
+import taboolib.module.nms.MinecraftVersion
 import trplugins.menu.module.display.MenuSession
 import trplugins.menu.module.display.session
 
@@ -11,10 +13,11 @@ import trplugins.menu.module.display.session
  */
 object ListenerLocale {
 
-    @SubscribeEvent
-    fun onLocaleChange(e: PlayerLocaleChangeEvent) {
-        if (MenuSession.langPlayer.isBlank()) {
-            e.player.session().locale = e.locale
+    @SubscribeEvent(bind = "org.bukkit.event.player.PlayerLocaleChangeEvent")
+    fun onLocaleChange(e: OptionalEvent) {
+        if (MinecraftVersion.majorLegacy >= 11200 && MenuSession.langPlayer.isBlank()) {
+            val event = e.get<PlayerLocaleChangeEvent>()
+            event.player.session().locale = event.locale
         }
     }
 


### PR DESCRIPTION
### Additions
* `enchant` method to item edit action, instead of `enchant-item` action this method can delete and override item enchantments.
  * Format: `edit-item: <operation> <item> enchant <enchantment> [level]`
* `color` method to item edit action to apply, delete or mix some color to leather armor, map or potion.
  * Format: `edit-item: <operation> <item> color [RGB separated by comma or spaces]`

### Changes
* Now TrMenu doesn't save empty data.

### Bug Fixes
* Fix locale listener on <1.12 severs.
* Fix deleted data not being updated on database.