### PR TITLE
Fix offhand glitch + meta.click_type keyword

### DIFF
--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowListener.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowListener.kt
@@ -101,7 +101,9 @@ object WindowListener {
         evt.call()
         receptacle.callEventClick(evt)
         if (evt.isCancelled) {
-            nmsProxy<NMS>().sendWindowsSetSlot(player, slot = -1, windowId = -1)
+            if(clickType == ReceptacleClickType.OFFHAND) {
+                nmsProxy<NMS>().sendWindowsSetSlot(player, windowId = 0, slot = 45)
+            } else nmsProxy<NMS>().sendWindowsSetSlot(player, slot = -1, windowId = -1)
         }
     }
 

--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowReceptacle.kt
@@ -111,6 +111,7 @@ open class WindowReceptacle(var type: WindowLayout, override var title: String =
     private fun initializationPackets() {
         if (viewer != null) {
             nmsProxy<NMS>().sendWindowsOpen(viewer!!, title = title, type = type)
+            nmsProxy<NMS>().sendWindowsSetSlot(viewer!!, windowId = 0, slot = 45)
             refresh()
         }
     }

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/layout/Layout.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/layout/Layout.kt
@@ -87,7 +87,10 @@ class Layout(
             }
 
             submit(async = false) {
-                Metadata.getMeta(session.viewer)["slot"] = "${event.slot}"
+                Metadata.getMeta(session.viewer).let {
+                    it["click_type"] = event.receptacleClickType.name
+                    it["slot"] = "${event.slot}"
+                }
                 session.getIconProperty(event.slot)?.handleClick(event.receptacleClickType, session)
             }
         }


### PR DESCRIPTION
### Changes
- Fixed a click glitch when using `offhand`, which caused the previous state to flash and created a ghost item when closing
- Added the meta.click_type keyword

#### before 
![My Movie 10](https://github.com/Dreeam-qwq/TrMenu/assets/48872538/7e3407fe-c2b6-4c84-a069-db528cdaf05a)
#### after
![My Movie 10](https://github.com/Dreeam-qwq/TrMenu/assets/48872538/7efa9e73-25fc-4037-85b5-3931c6de2b5f)

#### Setting click types manually
![My Movie 10](https://github.com/Dreeam-qwq/TrMenu/assets/48872538/8c854d77-5f57-45f0-be8d-1267ea4bd9ce)

#### Using meta.click_type
```yml
Icons.I:
  display:
    material: head:8e752a8ac734704f3f26184110232e420c5f2f7996c98f356d1293b90e8d6603
    name: '&fSelector'
    lore: '${js: Java.from(config.get("SELECTOR_LORE")).join("\n") }'
  actions.number_key: 'js: funcs("dynamicLore")'

Functions:
  dynamicLore: |-
    var stack = session.receptacle.getElement(meta.slot);
    var itemMeta = stack.getItemMeta(), lore = config.get("SELECTOR_LORE")
    var index = Math.min(meta.click_type.slice(-1) - 1, 3)
    lore.set(index, "§foption #${index}")
    itemMeta.setLore(lore); stack.setItemMeta(itemMeta)
    session.receptacle.setElement(stack, meta.slot, true)
    return true;
```
