### PR TITLE
3.3.5e

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ subprojects {
         }
         version {
 //            taboolib = "6.2.0-beta18"
-            taboolib = "6.2.0-beta33"
+            taboolib = "6.2.0-beta36"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.3.5c
+version=3.3.5e

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookGraalJS.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookGraalJS.kt
@@ -1,6 +1,7 @@
 package trplugins.menu.module.internal.hook.impl
 
 import taboolib.module.nms.MinecraftVersion
+import trplugins.menu.TrMenu
 import trplugins.menu.module.internal.hook.HookAbstract
 
 
@@ -12,6 +13,7 @@ class HookGraalJS : HookAbstract() {
 
     override val isHooked by lazy {
         if (!MinecraftVersion.isUniversal) return@lazy false
+        if (!TrMenu.SETTINGS.getBoolean("Scripts.Enable-GraalJS", false)) return@lazy false
         plugin != null && plugin!!.isEnabled
     }
 

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -96,4 +96,6 @@ RegisterCommands:
 Scripts:
   Export-Hook-Plugin: true
   Mozilla-Compat: true
+  # 是否启用 GraalJS 作为引擎
+  Enable-GraalJS: false
   Binding-Map:


### PR DESCRIPTION
更新 TabooLib 版本
修复 fakeOp 低版本无法使用问题
提供开关控制 GraalJS 是否作为引擎，防止线程卡死