### PR TITLE
Deprecate typo methods

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/script/Assist.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/script/Assist.kt
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.PlayerInventory
 import taboolib.common.platform.function.adaptPlayer
+import taboolib.common.platform.function.warning
 import taboolib.common.util.random
 import taboolib.library.xseries.XMaterial
 import taboolib.module.chat.Components
@@ -166,7 +167,13 @@ class Assist {
      * Internal - TabooLib Utils
      */
 
+    @Deprecated("Typo method name", ReplaceWith("getItemBuilder()"), DeprecationLevel.WARNING)
     fun getItemBuildr(): ItemBuilder {
+        warning("Assist#getItemBuildr() is deprecated, use getItemBuilder() instead.")
+        return ItemBuilder(XMaterial.STONE)
+    }
+
+    fun getItemBuilder(): ItemBuilder {
         return ItemBuilder(XMaterial.STONE)
     }
 


### PR DESCRIPTION
This pull request deprecated typo method `Assist#getItemBuildr()`, use correct method name as a replacement