### PR TITLE
refactor(database): 重写数据库模块

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,8 @@ subprojects {
                 Kether,
                 Metrics,
                 MinecraftChat,
-                XSeries
+                XSeries,
+                PtcObject
             )
             repoTabooLib = "https://repo.aeoliancloud.com/repository/releases"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.4.9
+version=3.5.0

--- a/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
@@ -5,7 +5,6 @@ import taboolib.common.platform.Plugin
 import taboolib.common.platform.function.console
 import taboolib.module.configuration.Config
 import taboolib.module.configuration.Configuration
-import taboolib.module.kether.Kether
 import taboolib.module.lang.Language
 import taboolib.module.lang.sendLang
 import taboolib.platform.BukkitPlugin
@@ -86,7 +85,6 @@ object TrMenu : Plugin() {
         Shortcuts.Type.load()
         RegisterCommands.load()
         Bindings.load()
-        Kether.isAllowToleranceParser = SETTINGS.getBoolean("Action.Kether.Allow-Tolerance-Parser", false)
         Tell.useComponent = SETTINGS.getBoolean("Action.Using-Component", true)
         PlatformProvider.compute()
         NMS.javaStaticInventory = SETTINGS.getBoolean("Options.Static-Inventory.Java", false)

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/DelGlobalData.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/DelGlobalData.kt
@@ -18,11 +18,9 @@ class DelGlobalData(handle: ActionHandle) : ActionBase(handle) {
     override val regex = "(remove|rem|del)-?(global|g)-?datas?".toRegex()
 
     override fun onExecute(contents: ActionContents, player: ProxyPlayer, placeholderPlayer: ProxyPlayer) {
-        val data = Metadata.globalData
-
         contents.stringContent().parseContentSplited(placeholderPlayer, ";").forEach { it ->
             val regex = Regex(it)
-            data.getKeys(true).filter { it.matches(regex) }.forEach { data[it] = null }
+            Metadata.getGlobalDataKeys().filter { it.matches(regex) }.forEach { Metadata.setGlobalData(it, null)}
         }
     }
 }

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/SetData.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/SetData.kt
@@ -25,6 +25,9 @@ class SetData(handle: ActionHandle) : ActionBase(handle) {
                 val value = split[1]
 
                 Metadata.getData(player)[key] = value
+                if (!Metadata.isUseLegacy) {
+                    Metadata.saveData(player.cast(), key)
+                }
             }
         }
     }

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/SetGlobalData.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/metadaa/SetGlobalData.kt
@@ -24,7 +24,7 @@ class SetGlobalData(handle: ActionHandle) : ActionBase(handle) {
                 val key = split[0]
                 val value = split[1]
 
-                Metadata.globalData[key] = value
+                Metadata.setGlobalData(key, value)
             }
         }
     }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/data/DataEntity.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/data/DataEntity.kt
@@ -1,0 +1,15 @@
+package trplugins.menu.module.internal.data
+
+import org.bukkit.entity.Player
+import taboolib.expansion.Length
+import java.util.*
+
+
+data class DataEntity(
+    val user: UUID,
+    val key: String,
+    @Length(-1)
+    val data: String
+) {
+    constructor(player: Player, key: String, data: String) : this(player.uniqueId, key, data)
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/data/GlobalDataEntity.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/data/GlobalDataEntity.kt
@@ -1,0 +1,9 @@
+package trplugins.menu.module.internal.data
+
+import taboolib.expansion.Length
+
+data class GlobalDataEntity(
+    val key: String,
+    @Length(-1)
+    val data: String
+)

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/database/GlobalDataDao.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/database/GlobalDataDao.kt
@@ -1,0 +1,45 @@
+package trplugins.menu.module.internal.database
+
+import taboolib.expansion.db
+import taboolib.expansion.persistentContainer
+import trplugins.menu.TrMenu
+import trplugins.menu.module.internal.data.GlobalDataEntity
+
+class GlobalDataDao {
+
+    private val table = "${TrMenu.SETTINGS.getString("Database.SQL.prefix", "trmenu")}_global_data".lowercase()
+
+    private val container by lazy {
+        persistentContainer(type = db("settings.yml", "Database.SQL", "global.db")) { new<GlobalDataEntity>(table) }
+    }
+
+    fun update(key: String, value: Any?) {
+        val containerx = container[table]
+        val old = get(key)
+        if (old == null) {
+            containerx.insert(listOf(GlobalDataEntity(key, value.toString())))
+        } else {
+            val tablex = containerx.table
+            val dataSource = containerx.dataSource
+            tablex.update(dataSource) {
+                where("key" eq key)
+                set("data", value?.toString() ?: "")
+            }
+
+        }
+    }
+
+    fun get(key: String): GlobalDataEntity? {
+        return container[table].getOne<GlobalDataEntity?> {
+            "key" eq key
+        }
+    }
+
+    fun get(): List<GlobalDataEntity> {
+        return container[table].get<GlobalDataEntity?>().filter { it?.data?.isNotEmpty() == true }.mapNotNull { it }
+    }
+
+    companion object {
+        val door by lazy { GlobalDataDao() }
+    }
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/database/MetaDataDao.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/database/MetaDataDao.kt
@@ -1,0 +1,50 @@
+package trplugins.menu.module.internal.database
+
+import taboolib.expansion.db
+import taboolib.expansion.persistentContainer
+import trplugins.menu.TrMenu
+import trplugins.menu.module.internal.data.DataEntity
+import java.util.*
+
+class MetaDataDao {
+
+    private val table = "${TrMenu.SETTINGS.getString("Database.SQL.prefix", "trmenu")}_data".lowercase()
+
+    private val container by lazy {
+        persistentContainer(type = db("settings.yml", "Database.SQL")) { new<DataEntity>(table) }
+    }
+
+    fun update(entity: DataEntity) {
+        val containerx = container[table]
+        val old = get(entity.user, entity.key)
+        if (old == null) {
+            containerx.insert(listOf(entity))
+        } else {
+            val tablex = containerx.table
+            val dataSource = containerx.dataSource
+            tablex.update(dataSource) {
+                where("user" eq entity.user.toString())
+                where("key" eq entity.key)
+                set("data", entity.data)
+            }
+
+        }
+    }
+
+    fun get(uuid: UUID): List<DataEntity> {
+        return container[table].get<DataEntity?> {
+            "user" eq uuid.toString()
+        }.filter { it?.data?.isNotEmpty() == true }.mapNotNull { it }
+    }
+
+    fun get(uuid: UUID, key: String): DataEntity? {
+        return container[table].getOne<DataEntity?> {
+            "user" eq uuid.toString()
+            "key" eq key
+        }
+    }
+
+    companion object {
+        val door by lazy { MetaDataDao() }
+    }
+}

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerJoin.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerJoin.kt
@@ -17,7 +17,7 @@ object ListenerJoin {
     fun onJoin(e: PlayerJoinEvent) {
         val player = e.player
 
-        submit(async = true, delay = TrMenu.SETTINGS.getLong("Database.Join_Load_Delay", 20)) {
+        submit(async = true, delay = TrMenu.SETTINGS.getLong("Database.Join-Load-Delay", 40)) {
             // 缓存玩家头颅备用
             Heads.getHead(player.name)
             // 加载 Metadata - Data 数据

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/script/FunctionParser.kt
@@ -21,7 +21,11 @@ object FunctionParser {
     private val functionPattern = "\\$?\\{(\\w+)s?: ?(.+?[^\\\\}])}".toRegex()
     private val internalFunctionPattern = "\\$\\{([^0-9].+?[^\\\\}])}".toRegex()
 
-    fun parse(player: Player, input: String, block: (type: String, value: String) -> String? = { _, value -> "{$value}" }): String {
+    fun parse(
+        player: Player,
+        input: String,
+        block: (type: String, value: String) -> String? = { _, value -> "{$value}" }
+    ): String {
         return runCatching {
             if (!Regexs.containsPlaceholder(input)) return input
             val session = MenuSession.getSession(player)
@@ -38,7 +42,7 @@ object FunctionParser {
                         "jexl" -> parseJexlScript(session, value)
                         "meta", "m" -> Metadata.getMeta(player)[value].toString()
                         "data", "d" -> Metadata.getData(player)[value].toString()
-                        "globaldata", "gdata", "g" -> runCatching { Metadata.globalData[value].toString() }.getOrElse { "null" }
+                        "globaldata", "gdata", "g" -> Metadata.getGlobalData(value)?.toString() ?: "null"
                         "triton" -> parseLangText(player, value)
 
                         else -> block(type, value) ?: "{${it.value}}"
@@ -83,7 +87,9 @@ object FunctionParser {
 
     private fun parseLangText(player: Player, text: String): String {
         val split = text.split("=", limit = 2)
-        return HookPlugin.getTriton().getText(player, split[0], if (split.size < 2) emptyArray() else split[1].split("_||_").toTypedArray()).toString()
+        return HookPlugin.getTriton()
+            .getText(player, split[0], if (split.size < 2) emptyArray() else split[1].split("_||_").toTypedArray())
+            .toString()
     }
 
 }

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -31,26 +31,40 @@ Language:
     en_nz: 'en_US'
 
 Database:
+  # 使用旧版数据库储存
+  Use-Legacy-Database: false
+
   # Local: SQLITE
-  # External: SQL, MONGODB
+  # External: SQL
   Method: SQLITE
   Type:
     SQLite:
       file-name: data
-      table: npc
     SQL:
       host: localhost
       port: 3306
       user: root
       password: root
       database: test
-      table: trmenu_user_data
   Index:
     # UUID, USERNAME
     Player: USERNAME
 
+  # 新版数据库模块
+  SQL:
+    # 启用 MYSQL, 否则使用 SQLITE
+    enable: false
+    host: localhost
+    port: 3306
+    user: root
+    password: root
+    database: minecraft
+    prefix: trmenu
+
   # 进服延迟加载数据
-  Join_Load_Delay: 20
+  Join-Load-Delay: 40
+  # 全局数据跨服同步间隔
+  Global-Data-Sync: 200
 
 Loader:
   Listen-Files: true
@@ -73,8 +87,6 @@ Action:
     Cancel-Words:
       - 'cancel|quit|end'
       - 'q'
-  Kether:
-    Allow-Tolerance-Parser: true
 
 
 Shortcuts:


### PR DESCRIPTION
- 新增配置选项选择使用新版数据库模块
- 新增 GlobalDataDao 和 MetaDataDao 类用于数据库操作
- 在 Metadata 类中实现全局数据加载和持久化方法
- 更新 SetData 和 SetGlobalData 动作以支持数据库存储
- 优化 DelGlobalData动作的执行逻辑
- 调整 FunctionParser 以适应新的全局数据获取方式
- 更新插件配置文件，增加数据库相关设置