### PR TITLE
feat(plugin): 添加在远程获取头颅信息时的连接/读取超时设置

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/util/bukkit/Heads.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/util/bukkit/Heads.kt
@@ -150,6 +150,8 @@ object Heads {
         try {
             val con = URL(url).openConnection()
             // Java 8 require user agent
+            con.connectTimeout = 500
+            con.readTimeout = 2500
             con.addRequestProperty("User-Agent", "Mozilla/5.0")
             con.getInputStream().use { `in` ->
                 BufferedReader(InputStreamReader(`in`)).use { reader ->


### PR DESCRIPTION
如题, 添加在远程获取头颅信息时的连接/读取超时设置, 具体配置为:
- connectTimeout 连接超时时长 500ms
- readTimeout 读取超时时长 2500ms

## 背景
在玩家打开菜单时，若服务器的网络恰好出现波动, 导致连接/读取的时间较长, 由于该操作为主线程操作, 就会出现服务器滞后甚至崩溃的问题 (本人服务器已经因此而崩溃了若干次), 改后代码所设置的超时可实现基本不对服务器造成滞后：
```log
[10:37:11 INFO]: alazeprt issued server command: /menu open Main
[10:37:11 INFO]: Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]
[10:37:17 WARN]: Couldn't look up profile properties for d112f005-1681-3f49-9abc-f0056bbbe926
com.mojang.authlib.exceptions.MinecraftClientException: Failed to read from https://sessionserver.mojang.com/session/minecraft/profile/d112f00516813f499abcf0056bbbe926?unsigned=false due to Read timed out
        at com.mojang.authlib.minecraft.client.MinecraftClient.readInputStream(MinecraftClient.java:111) ~[authlib-6.0.57.jar:?]
        at com.mojang.authlib.minecraft.client.MinecraftClient.get(MinecraftClient.java:56) ~[authlib-6.0.57.jar:?]
        at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfileUncached(YggdrasilMinecraftSessionService.java:201) ~[authlib-6.0.57.jar:?]
        at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfile(YggdrasilMinecraftSessionService.java:171) ~[authlib-6.0.57.jar:?]
        at com.destroystokyo.paper.profile.PaperMinecraftSessionService.fetchProfile(PaperMinecraftSessionService.java:35) ~[leaf-1.21.4.jar:1.21.4-496-5311ae8]
        at org.bukkit.craftbukkit.profile.CraftPlayerProfile.getUpdatedProfile(CraftPlayerProfile.java:180) ~[leaf-1.21.4.jar:1.21.4-496-5311ae8]
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.VirtualThread.run(VirtualThread.java:329) ~[?:?]
Caused by: java.net.SocketTimeoutException: Read timed out
        at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:278) ~[?:?]
        at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:304) ~[?:?]
        at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:346) ~[?:?]
        at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:796) ~[?:?]
        at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1099) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketInputRecord.readFully(SSLSocketInputRecord.java:472) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketInputRecord.decodeInputRecord(SSLSocketInputRecord.java:243) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:181) ~[?:?]
        at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455) ~[?:?]
        at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426) ~[?:?]
        at java.base/sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:586) ~[?:?]
        at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:187) ~[?:?]
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1675) ~[?:?]
        at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1599) ~[?:?]
        at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:531) ~[?:?]
        at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:307) ~[?:?]
        at com.mojang.authlib.minecraft.client.MinecraftClient.readInputStream(MinecraftClient.java:82) ~[authlib-6.0.57.jar:?]
        ... 9 more
[10:37:18 INFO]: [XConomy] Check update failed
> tps
[10:37:21 ERROR]: --- DO NOT REPORT THIS TO PAPER - If you think this is a Leaf bug, please report it at https://github.com/Winds-Studio/Leaf/issues - THIS IS NOT A PAPER BUG OR CRASH - 1.21.4-496-5311ae8 (MC: 1.21.4) ---
[10:37:21 ERROR]: The server has not responded for 10 seconds! Creating thread dump
[10:37:21 ERROR]: ------------------------------
[10:37:21 ERROR]: Server thread dump (Look for plugins here before reporting to Leaf!):
[10:37:21 ERROR]: ------------------------------
[10:37:21 ERROR]: Current Thread: Server thread
[10:37:21 ERROR]:       PID: 79 | Suspended: false | Native: true | State: RUNNABLE
[10:37:21 ERROR]:       Stack:
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.SocketDispatcher.read0(Native Method)
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:46)
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.NioSocketImpl.tryRead(NioSocketImpl.java:256)
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:307)
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:346)
[10:37:21 ERROR]:               java.base@21.0.4/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:796)
[10:37:21 ERROR]:               java.base@21.0.4/java.net.Socket$SocketInputStream.read(Socket.java:1099)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketInputRecord.readFully(SSLSocketInputRecord.java:472)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketInputRecord.decodeInputRecord(SSLSocketInputRecord.java:243)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:181)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1506)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1421)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
[10:37:21 ERROR]:               java.base@21.0.4/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
[10:37:21 ERROR]:               java.base@21.0.4/sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:586)
[10:37:21 ERROR]:               java.base@21.0.4/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:187)
[10:37:21 ERROR]:               java.base@21.0.4/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1675)
[10:37:21 ERROR]:               java.base@21.0.4/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1599)
[10:37:21 ERROR]:               java.base@21.0.4/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:223)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.util.bukkit.Heads.urlText(Heads.kt:156)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.util.bukkit.Heads.urlJson(Heads.kt:141)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.util.bukkit.Heads.seekTexture(Heads.kt:120)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.util.bukkit.Heads.getPlayerHead(Heads.kt:87)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.util.bukkit.Heads.getHead(Heads.kt:49)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.texture.Texture.generate(Texture.kt:41)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.item.Item.generate(Item.kt:77)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.item.Item.build(Item.kt:109)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.item.Item.build$default(Item.kt:104)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.item.Item.get(Item.kt:67)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.icon.Icon.settingItem(Icon.kt:78)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.icon.Icon.filter(Icon.kt:154)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.icon.Icon.onRefresh(Icon.kt:83)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.Menu.loadIcon(Menu.kt:222)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.display.Menu.open(Menu.kt:112)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.internal.command.impl.CommandOpen.command$lambda$15$lambda$14$lambda$6(CommandOpen.kt:47)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.module.internal.command.impl.CommandOpen$$Lambda/0x00000238c19a3568.invoke(Unknown Source)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.common.platform.command.component.CommandExecutor.exec(CommandExecutor.kt:11)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.common.platform.command.component.CommandBase.execute$process(CommandBase.kt:118)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.common.platform.command.component.CommandBase.execute$process(CommandBase.kt:104)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.common.platform.command.component.CommandBase.execute(CommandBase.kt:131)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.common.platform.command.CommandRegisterKt$command$1.execute(CommandRegister.kt:40)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.platform.BukkitCommand$registerCommand$1.invoke$lambda$0(BukkitCommand.kt:76)
[10:37:21 ERROR]:               TrMenu-3.6.3.jar//me.arasple.mc.trmenu.taboolib.platform.BukkitCommand$registerCommand$1$$Lambda/0x00000238c16c3508.onCommand(Unknown Source)
[10:37:21 ERROR]:               org.bukkit.command.PluginCommand.execute(PluginCommand.java:45)
[10:37:21 ERROR]:               io.papermc.paper.command.brigadier.bukkit.BukkitCommandNode$BukkitBrigCommand.run(BukkitCommandNode.java:82)
[10:37:21 ERROR]:               com.mojang.brigadier.context.ContextChain.runExecutable(ContextChain.java:73)
[10:37:21 ERROR]:               net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:29)
[10:37:21 ERROR]:               net.minecraft.commands.execution.tasks.ExecuteCommand.execute(ExecuteCommand.java:13)
[10:37:21 ERROR]:               net.minecraft.commands.execution.UnboundEntryAction.lambda$bind$0(UnboundEntryAction.java:8)
[10:37:21 ERROR]:               net.minecraft.commands.execution.UnboundEntryAction$$Lambda/0x00000238c19b2688.execute(Unknown Source)
[10:37:21 ERROR]:               net.minecraft.commands.execution.CommandQueueEntry.execute(CommandQueueEntry.java:5)
[10:37:21 ERROR]:               net.minecraft.commands.execution.ExecutionContext.runCommandQueue(ExecutionContext.java:103)
[10:37:21 ERROR]:               net.minecraft.commands.Commands.executeCommandInContext(Commands.java:430)
[10:37:21 ERROR]:               net.minecraft.commands.Commands.performCommand(Commands.java:362)
[10:37:21 ERROR]:               net.minecraft.commands.Commands.performCommand(Commands.java:353)
[10:37:21 ERROR]:               net.minecraft.commands.Commands.performCommand(Commands.java:347)
[10:37:21 ERROR]:               net.minecraft.server.network.ServerGamePacketListenerImpl.performUnsignedChatCommand(ServerGamePacketListenerImpl.java:2307)
[10:37:21 ERROR]:               net.minecraft.server.network.ServerGamePacketListenerImpl.lambda$handleChatCommand$15(ServerGamePacketListenerImpl.java:2280)
[10:37:21 ERROR]:               net.minecraft.server.network.ServerGamePacketListenerImpl$$Lambda/0x00000238c19b51a8.run(Unknown Source)
[10:37:21 ERROR]:               net.minecraft.server.TickTask.run(TickTask.java:18)
[10:37:21 ERROR]:               net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155)
[10:37:21 ERROR]:               net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1495)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:165)
[10:37:21 ERROR]:               net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1476)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1470)
[10:37:21 ERROR]:               net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:139)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1425)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1434)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1314)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:300)
[10:37:21 ERROR]:               net.minecraft.server.MinecraftServer$$Lambda/0x00000238c0e51b80.run(Unknown Source)
[10:37:21 ERROR]:               java.base@21.0.4/java.lang.Thread.runWith(Thread.java:1596)
[10:37:21 ERROR]:               java.base@21.0.4/java.lang.Thread.run(Thread.java:1583)
[10:37:21 ERROR]: ------------------------------
[10:37:21 ERROR]: Parallel world ticking thread dump
[10:37:21 ERROR]: ------------------------------
[10:37:21 ERROR]: --- DO NOT REPORT THIS TO PAPER - If you think this is a Leaf bug, please report it at https://github.com/Winds-Studio/Leaf/issues - THIS IS NOT A PAPER BUG OR CRASH ---
[10:37:21 ERROR]: ------------------------------
```