### PR TITLE
fix(listener): 修正CraftInventory类的导入路径

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
@@ -53,11 +53,7 @@ object ListenerItemInteract {
     class InventoryNMSImpl : InventoryNMS() {
 
         private val `clazz$CraftInventoryCustom$MinecraftInventory` =
-            if (versionId >= 12108) {
-                obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
-            } else {
-                obcClass("org.bukkit.craftbukkit.inventory.CraftInventoryCustom\$MinecraftInventory")
-            }
+            obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
 
         override fun checkInventory(inventory: Inventory): Boolean {
             return `clazz$CraftInventoryCustom$MinecraftInventory`.isInstance((inventory as CraftInventory).inventory)

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
@@ -53,7 +53,11 @@ object ListenerItemInteract {
     class InventoryNMSImpl : InventoryNMS() {
 
         private val `clazz$CraftInventoryCustom$MinecraftInventory` =
-            obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
+            if (versionId >= 12108) {
+                obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
+            } else {
+                obcClass("org.bukkit.craftbukkit.inventory.CraftInventoryCustom\$MinecraftInventory")
+            }
 
         override fun checkInventory(inventory: Inventory): Boolean {
             return `clazz$CraftInventoryCustom$MinecraftInventory`.isInstance((inventory as CraftInventory).inventory)

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
@@ -53,7 +53,7 @@ object ListenerItemInteract {
     class InventoryNMSImpl : InventoryNMS() {
 
         private val `clazz$CraftInventoryCustom$MinecraftInventory` =
-            obcClass("org.bukkit.craftbukkit.inventory.CraftInventoryCustom\$MinecraftInventory")
+            obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
 
         override fun checkInventory(inventory: Inventory): Boolean {
             return `clazz$CraftInventoryCustom$MinecraftInventory`.isInstance((inventory as CraftInventory).inventory)


### PR DESCRIPTION
fix #211

```
Caused by: java.lang.ClassNotFoundException: org.bukkit.craftbukkit.org.bukkit.craftbukkit.inventory.CraftInventoryCustom$MinecraftInventory
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:349) ~[?:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557) ~[?:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490) ~[?:?]
        at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
        at java.base/java.lang.Class.forName(Class.java:543) ~[?:?]
        at io.papermc.reflectionrewriter.runtime.AbstractDefaultRulesReflectionProxy.forName(AbstractDefaultRulesReflectionProxy.java:73) ~[reflection-rewriter-runtime-0.0.3.jar:?]
        at io.papermc.paper.pluginremap.reflect.PaperReflectionHolder.forName(Unknown Source) ~[paper-1.21.8.jar:1.21.8-50-51706e5]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[?:?]
        at java.base/java.lang.reflect.Method.invoke(Method.java:565) ~[?:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.module.nms.LightReflection.forName(LightReflection.java:65) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.module.nms.LightReflection$1.getClass(LightReflection.java:52) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.common.TabooLib.getClass(TabooLib.java:199) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.common.reflect.ClassHelper.getClass(ClassHelper.java:934) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.common.reflect.ClassHelper.getClass(ClassHelper.java:1000) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.common.reflect.ClassHelper.getClass(ClassHelper.java:983) ~[TrMenu-3.8.4.jar:?]
        at TrMenu-3.8.4.jar/me.arasple.mc.trmenu.taboolib.module.nms.MinecraftServerUtilKt.obcClass(MinecraftServerUtil.kt:52) ~[TrMenu-3.8.4.jar:?]
        at me.arasple.mc.trmenu.module.internal.listener.ListenerItemInteract$InventoryNMSImpl.<init>(ListenerItemInteract.kt:56) ~[?:?]
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
        ... 46 more
```