### PR TITLE
build: 更新 TabooLib 版本并调整构建配置

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,15 @@ tasks.build {
     }
     dependsOn(project(":plugin").tasks.build)
 }
+tasks.taboolibBuildApi {
+    doLast {
+        val plugin = project(":plugin")
+        val file =
+            file("${plugin.layout.buildDirectory.get()}/libs").listFiles()?.find { it.endsWith("plugin-$version-api.jar") }
+
+        file?.copyTo(file("${project.layout.buildDirectory.get()}/libs/${project.name}-$version-api.jar"), true)
+    }
+}
 
 subprojects {
 
@@ -62,7 +71,7 @@ subprojects {
             disableOnSkippedVersion = false
         }
         version {
-            taboolib = "6.2.3-6bdc1c7"
+            taboolib = "6.2.3-18c77c6a"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.8.4
+version=3.8.5


### PR DESCRIPTION
- 升级 TabooLib 版本从 6.2.3-6bdc1c7 到6.2.3-18c77c6a 支持最新版