### PR TITLE
build(deps): 更新 TabooLib 版本修复 Folia 服务端牌子捕获问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ subprojects {
             disableOnSkippedVersion = false
         }
         version {
-            taboolib = "6.2.3-18c77c6a"
+            taboolib = "6.2.3-c573ce52"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.8.5
+version=3.8.6

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/MenuSettings.kt
@@ -52,7 +52,7 @@ class MenuSettings(
                 val registered = PlaceholderAPI.getRegisteredIdentifiers()
                 field.filter { ex -> registered.none { it.equals(ex, true) } }.toTypedArray()
             } else {
-                arrayOf("PLUGINCORE")
+                arrayOf("PlaceholderAPI Plugin")
             }
         }
 


### PR DESCRIPTION
- 将 TabooLib 版本从 6.2.3-18c77c6a 更新至 6.2.3-c573ce52
- 修改缺少 PlaceholderAPI 插件提示名称，由 PLUGINCORE 更正为 PlaceholderAPI Plugin