### PR TITLE
chore(plugin): 修复频繁调用 inventory.holder 卡服问题

### DIFF
--- a/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowListener.kt
+++ b/api/receptacle/src/main/kotlin/trplugins/menu/api/receptacle/vanilla/window/WindowListener.kt
@@ -17,6 +17,7 @@ import trplugins.menu.api.receptacle.ReceptacleCloseEvent
 import trplugins.menu.api.receptacle.ReceptacleInteractEvent
 import trplugins.menu.api.receptacle.getViewingReceptacle
 import trplugins.menu.api.receptacle.vanilla.window.NMS.Companion.useStaticInventory
+import trplugins.menu.api.receptacle.vanilla.window.StaticInventory.staticInventory
 
 @PlatformSide(Platform.BUKKIT)
 object WindowListener {
@@ -67,6 +68,7 @@ object WindowListener {
 
     @SubscribeEvent
     fun onClick(e: InventoryClickEvent) {
+        (e.whoClicked as? Player)?.staticInventory ?: return
         if (e.inventory.holder is StaticInventory.Holder) {
             e.isCancelled = true
 
@@ -81,6 +83,7 @@ object WindowListener {
 
     @SubscribeEvent
     fun onClose(e: InventoryCloseEvent) {
+        (e.player as? Player)?.staticInventory ?: return
         if (e.inventory.holder is StaticInventory.Holder) {
             val player = e.player as? Player ?: return
             val receptacle = player.getViewingReceptacle() as? WindowReceptacle ?: return
@@ -91,6 +94,7 @@ object WindowListener {
 
     @SubscribeEvent
     fun onDrag(e: InventoryDragEvent) {
+        (e.whoClicked as? Player)?.staticInventory ?: return
         if (e.inventory.holder is StaticInventory.Holder) {
             e.isCancelled = true
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.8.7
+version=3.8.8

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/listener/ListenerItemInteract.kt
@@ -47,23 +47,4 @@ object ListenerItemInteract {
         }
     }
 
-    class InventoryNMSImpl : InventoryNMS() {
-
-        private val `clazz$CraftInventoryCustom$MinecraftInventory` =
-            obcClass("inventory.CraftInventoryCustom\$MinecraftInventory")
-
-        override fun checkInventory(inventory: Inventory): Boolean {
-            return `clazz$CraftInventoryCustom$MinecraftInventory`.isInstance((inventory as CraftInventory).inventory)
-        }
-
-    }
-
-    abstract class InventoryNMS {
-        abstract fun checkInventory(inventory: Inventory): Boolean
-
-        companion object {
-            val instance by lazy { nmsProxy<InventoryNMS>() }
-        }
-    }
-
 }

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/service/Shortcuts.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/service/Shortcuts.kt
@@ -7,6 +7,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerSwapHandItemsEvent
 import org.bukkit.event.player.PlayerToggleSneakEvent
 import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.PlayerInventory
 import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.common.platform.function.adaptPlayer
@@ -14,6 +15,7 @@ import taboolib.module.nms.MinecraftVersion
 import trplugins.menu.TrMenu
 import trplugins.menu.TrMenu.actionHandle
 import trplugins.menu.api.reaction.Reactions
+import trplugins.menu.api.receptacle.vanilla.window.WindowListener
 import trplugins.menu.module.display.MenuSession
 import trplugins.menu.module.internal.data.Metadata
 
@@ -111,6 +113,7 @@ object Shortcuts {
     @SubscribeEvent(ignoreCancelled = true)
     fun onClick(e: InventoryClickEvent) {
         val player = e.whoClicked as Player
+        if (e.inventory !is PlayerInventory) return
 
         if (player.openInventory.topInventory.holder == player.inventory.holder && e.slot < 0) {
             borderClick(player, e.click)

--- a/plugin/src/main/kotlin/trplugins/menu/util/bukkit/ItemHelper.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/util/bukkit/ItemHelper.kt
@@ -92,7 +92,7 @@ object ItemHelper {
     fun fromJson(json: String): ItemStack? {
         try {
             // 自动判别老式/新式 NBT 标签
-            if (HookPlugin.getNBTAPI().isHooked && json.startsWith("{\"item\":")) {
+            if (json.startsWith("{\"item\":") && HookPlugin.getNBTAPI().isHooked) {
                 return HookPlugin.getNBTAPI().fromJson(json)
             }
             val parse = JsonParser().parse(json)


### PR DESCRIPTION
- 将插件版本升级至 3.8.8
- 移除废弃的 InventoryNMSImpl 和 InventoryNMS 类
- 在 Shortcuts 中增加对 PlayerInventory 的判断以避免非玩家背包点击事件处理
- 为 WindowListener 增加静态菜单类型检查，防止非法操作触发卡服
- 修改JSON解析条件判断顺序，优先检查JSON格式
- 避免因插件未加载导致的线程卡死