### PR TITLE
chore(deps): 更新 Taboolib 版本支持 CatServer1.12.2 等服务端

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ subprojects {
             disableOnSkippedVersion = false
         }
         version {
-            taboolib = "6.2.4-1c0dbc5c"
+            taboolib = "6.2.4-7f8b30dc"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.9.9
+version=3.9.10


### PR DESCRIPTION
- 将 Taboolib 更新至 6.2.4-7f8b30dc
- 更新项目版本号至 3.9.10