### PR TITLE
chore: 更新依赖版本并优化数据处理逻辑

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ subprojects {
             disableOnSkippedVersion = false
         }
         version {
-            taboolib = "6.2.4-7f8b30dc"
+            taboolib = "6.2.4-abd325ee"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.9.10
+version=3.9.11

--- a/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/conf/MenuSerializer.kt
@@ -42,6 +42,8 @@ import trplugins.menu.util.collections.IndivList
 import trplugins.menu.util.conf.Property
 import trplugins.menu.util.parseIconId
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.collections.forEach
 import kotlin.jvm.optionals.getOrNull
 import kotlin.math.max
 
@@ -104,10 +106,10 @@ object MenuSerializer : ISerializer {
         }
 
         // 读取菜单语言
-        val lang: Map<String, HashMap<String, taboolib.module.lang.Type>>? = if (languages.isEmpty()) null else {
-            val map = HashMap<String, HashMap<String, taboolib.module.lang.Type>>()
+        val lang: Map<String, ConcurrentHashMap<String, taboolib.module.lang.Type>>? = if (languages.isEmpty()) null else {
+            val map = mutableMapOf<String, ConcurrentHashMap<String, taboolib.module.lang.Type>>()
             languages.forEach { entry ->
-                val nodes = serializeLocaleNodes(entry.key, entry.value, HashMap())
+                val nodes = serializeLocaleNodes(entry.key, entry.value, ConcurrentHashMap())
                 if (nodes.isNotEmpty()) {
                     map[entry.key.lowercase()] = nodes
                 }
@@ -432,7 +434,7 @@ object MenuSerializer : ISerializer {
     // Method body taken from Taboolib, licensed under the MIT License
     //
     // Copyright (c) 2018 Bkm016
-    private fun serializeLocaleNodes(code: String, file: ConfigurationSection, nodes: HashMap<String, taboolib.module.lang.Type>, root: String = ""): HashMap<String, taboolib.module.lang.Type> {
+    private fun serializeLocaleNodes(code: String, file: ConfigurationSection, nodes: ConcurrentHashMap<String, taboolib.module.lang.Type>, root: String = ""): ConcurrentHashMap<String, taboolib.module.lang.Type> {
         file.getKeys(false).forEach { node ->
             val key = "$root$node"
             when (val obj = file[node]) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -34,7 +34,7 @@ class Menu(
     val icons: Set<Icon>,
     conf: Configuration,
     private val langKey: String? = null,
-    lang: Map<String, HashMap<String, Type>>? = null
+    lang: Map<String, Map<String, Type>>? = null
 ) {
 
     companion object {
@@ -47,7 +47,7 @@ class Menu(
     var conf: Configuration = conf
         internal set
 
-    var lang: Map<String, HashMap<String, Type>>? = lang
+    var lang: Map<String, Map<String, Type>>? = lang
         internal set
 
     val viewers: MutableSet<String> = mutableSetOf()

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
@@ -49,6 +49,7 @@ object Metadata {
 
     // Copy in the Adyeshach
     val database by lazy {
+        if (!isUseLegacy) return@lazy null
         when (val db = SETTINGS.getString("Database.Method")?.uppercase()) {
             "LOCAL", "SQLITE", null -> DatabaseSQLite()
             "SQL" -> DatabaseSQL()
@@ -90,7 +91,7 @@ object Metadata {
 
     fun pushData(player: Player, dataMap: DataMap = getData(player)) {
         if (isUseLegacy) {
-            getLocalePlayer(player).let {
+            getLocalePlayer(player)?.let {
                 it.getConfigurationSection("TrMenu.Data")?.getKeys(true)?.forEach { key ->
                     if (!dataMap.data.containsKey(key)) {
                         it["TrMenu.Data.$key"] = null
@@ -98,7 +99,7 @@ object Metadata {
                 }
                 dataMap.data.forEach { (key, value) -> it["TrMenu.Data.$key"] = value }
             }
-            database.push(player)
+            database?.push(player)
         } else {
             dataMap.data.forEach { (key, value) ->
                 MetaDataDao.door.update(DataEntity.constructor(player, key, value?.toString() ?: ""))
@@ -106,15 +107,15 @@ object Metadata {
         }
     }
 
-    private fun getLocalePlayer(player: Player): Configuration {
-        return database.pull(player)
+    private fun getLocalePlayer(player: Player): Configuration? {
+        return database?.pull(player)
     }
 
     fun loadData(player: Player) {
         val map: MutableMap<String, Any?> = mutableMapOf()
 
         if (isUseLegacy) {
-            getLocalePlayer(player).getConfigurationSection("TrMenu.Data")?.let { section ->
+            getLocalePlayer(player)?.getConfigurationSection("TrMenu.Data")?.let { section ->
                 section.getKeys(true).forEach { key -> map[key] = section[key] }
             }
         } else {


### PR DESCRIPTION
- 将 taboolib 版本从 6.2.4-7f8b30dc 更新至 6.2.4-abd325ee
- 插件版本号从 3.9.10 升级到 3.9.11
- 修改 Menu 类中的 lang 字段类型为 Map<String, Map<String, Type>>
- 在 MenuSerializer 中使用 ConcurrentHashMap 替代 HashMap 提高并发安全性
- 优化 Metadata 类的数据加载与推送逻辑，增强空安全处理
- 当 isUseLegacy 为 false 时，database 初始化返回 null 避免不必要的实例化