### PR TITLE
chore(version): 3.9.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.9.14
+version=3.9.15

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/data/Metadata.kt
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.metadata.FixedMetadataValue
 import taboolib.common.LifeCycle
+import taboolib.common.env.RuntimeDependency
 import taboolib.common.platform.Awake
 import taboolib.common.platform.ProxyPlayer
 import taboolib.common.platform.Schedule
@@ -34,6 +35,12 @@ import java.util.concurrent.ConcurrentHashMap
  * <meta> -> only lost when the server is shut down
  * <data> -> storable, (support MongoDB)
  */
+@RuntimeDependency(
+    value = "!org.slf4j:slf4j-jdk14:2.0.8",
+    test = "!org.slf4j_2_0_8.jul.JULServiceProvider",
+    relocate = ["!org.slf4j", "!org.slf4j_2_0_8"],
+    transitive = false
+)
 object Metadata {
 
     internal val meta = mutableMapOf<String, DataMap>()


### PR DESCRIPTION
- 更新插件时需删除 cache/taboolib 目录
- 添加 slf4j-jdk14 作为运行时依赖项
- 更新 gradle.properties 中的版本号