### PR TITLE
chore(deps): 更新 TabooLib 支持 1.21.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### 🔔 What's new in this fork?
 
-- **Support 1.8.9 ~ 1.21.8**
+- **Support 1.8.9 ~ 1.21.11**
 - **Fix Skull display**
 - **[International Language](https://github.com/Dreeam-qwq/TrMenu/pull/64)**
 - **Something more...**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ subprojects {
             disableOnSkippedVersion = false
         }
         version {
-            taboolib = "6.2.4-65252583"
+            taboolib = "6.2.4-5902762"
             coroutines = null
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.9.15
+version=3.9.16


### PR DESCRIPTION
- 将 taboolib 版本从 6.2.4-65252583 更新至 6.2.4-5902762
- 更新项目版本号从 3.9.15 到 3.9.16
- README.md 中支持版本范围为 1.8.9 ~ 1.21.11