### PR TITLE
feat: add MiniMessage format support for menu title

### DIFF
--- a/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/TrMenu.kt
@@ -95,6 +95,7 @@ object TrMenu : Plugin() {
         Bindings.load()
         Tell.useComponent = SETTINGS.getBoolean("Action.Using-Component", true)
         SetTitle.useComponent = if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_14)) SETTINGS.getBoolean("Action.Title-Using-Component", false) else false
+        SetTitle.useMiniMessage = if (MinecraftVersion.isHigherOrEqual(MinecraftVersion.V1_16)) SETTINGS.getBoolean("Action.Title-MiniMessage", false) else false
         PlatformProvider.compute()
         NMS.javaStaticInventory = SETTINGS.getBoolean("Options.Static-Inventory.Java", false)
         NMS.bedrockStaticInventory = SETTINGS.getBoolean("Options.Static-Inventory.Bedrock", false)

--- a/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetTitle.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/api/action/impl/menu/SetTitle.kt
@@ -6,6 +6,7 @@ import trplugins.menu.api.action.ActionHandle
 import trplugins.menu.api.action.base.ActionBase
 import trplugins.menu.api.action.base.ActionContents
 import trplugins.menu.module.display.session
+import trplugins.menu.util.MiniMessageUtil
 import trplugins.menu.util.colorify
 import trplugins.menu.util.parseJson
 
@@ -19,6 +20,7 @@ import trplugins.menu.util.parseJson
 class SetTitle(handle: ActionHandle) : ActionBase(handle) {
     companion object {
         var useComponent = true
+        var useMiniMessage = false
     }
 
     override val regex = "set-?title".toRegex()
@@ -27,12 +29,12 @@ class SetTitle(handle: ActionHandle) : ActionBase(handle) {
         val session = player.session()
         val receptacle = session.receptacle ?: return
         var title = contents.stringContent().parseContent(placeholderPlayer)
-        title = if (useComponent && runCatching { title.parseJson() }.isSuccess) {
-            title
-        } else {
-            title.colorify()
+        title = when {
+            useComponent && runCatching { title.parseJson() }.isSuccess -> title
+            useMiniMessage -> MiniMessageUtil.toJson(title)
+            else -> title.colorify()
         }
-        if (useComponent) {
+        if (useComponent || useMiniMessage) {
             title = title.component().build().toRawMessage()
         }
         receptacle.title(title)

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/Menu.kt
@@ -23,6 +23,7 @@ import trplugins.menu.module.display.layout.MenuLayout
 import trplugins.menu.module.internal.data.Metadata
 import trplugins.menu.module.internal.script.evalAction
 import trplugins.menu.module.internal.script.evalScript
+import trplugins.menu.util.MiniMessageUtil
 import trplugins.menu.util.colorify
 import trplugins.menu.util.parseJson
 import java.util.function.Consumer
@@ -238,12 +239,12 @@ class Menu(
     }
 
     private fun formatTitle(title: String): String {
-        val colored = if (SetTitle.useComponent && runCatching { title.parseJson() }.isSuccess) {
-            title
-        } else {
-            title.colorify()
+        val colored = when {
+            SetTitle.useComponent && runCatching { title.parseJson() }.isSuccess -> title
+            SetTitle.useMiniMessage -> MiniMessageUtil.toJson(title)
+            else -> title.colorify()
         }
-        return if (SetTitle.useComponent) colored.component().build().toRawMessage() else colored
+        return if (SetTitle.useComponent || SetTitle.useMiniMessage) colored.component().build().toRawMessage() else colored
     }
 
     private fun loadIcon(session: MenuSession) {

--- a/plugin/src/main/kotlin/trplugins/menu/util/MiniMessageUtil.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/util/MiniMessageUtil.kt
@@ -1,0 +1,30 @@
+package trplugins.menu.util
+
+/**
+ * @author Anahes37
+ * @date 2026/05/11 14:45
+ */
+object MiniMessageUtil {
+
+    private val MINI_MESSAGE_PATTERN = Regex("<[a-zA-Z#!][^<>]*>")
+
+    fun hasMiniMessageTags(text: String): Boolean = MINI_MESSAGE_PATTERN.containsMatchIn(text)
+
+    fun toJson(text: String): String {
+        return runCatching {
+            val mm = Class.forName("net.kyori.adventure.text.minimessage.MiniMessage")
+                .getMethod("miniMessage")
+                .invoke(null)
+            val component = mm.javaClass
+                .getMethod("deserialize", String::class.java)
+                .invoke(mm, text)
+            val gson = Class.forName("net.kyori.adventure.text.serializer.gson.GsonComponentSerializer")
+                .getMethod("gson")
+                .invoke(null)
+            val componentClass = Class.forName("net.kyori.adventure.text.Component")
+            gson.javaClass
+                .getMethod("serialize", componentClass)
+                .invoke(gson, component) as String
+        }.getOrElse { text.colorify() }
+    }
+}

--- a/plugin/src/main/resources/settings.yml
+++ b/plugin/src/main/resources/settings.yml
@@ -94,6 +94,9 @@ Menu:
 Action:
   Using-Component: true
   Title-Using-Component: true
+  # Whether to use MiniMessage format for menu titles (Requires Paper 1.16+, mutually exclusive with Title-Using-Component)
+  # Supports tags like: <red>text</red>, <bold>, <gradient:red:blue>gradient</gradient>, <rainbow>rainbow</rainbow>, etc.
+  Title-MiniMessage: false
   Inputer:
     Cancel-Words:
       - 'cancel|quit|end'


### PR DESCRIPTION
## 简介
解决#255

增加对在菜单标题 (`Title`) 中使用 MiniMessage 格式的支持。

## 改动内容
- 增加 `Action.Title-MiniMessage: true` 设置（需要在 `settings.yml` 中配置），作为 `Title-Using-Component` 的新模式（二选一）。
- 通过反射调用 Adventure API 的 `MiniMessage` 类（Paper 1.16+ 默认内置，不需要额外向项目引入新依赖）。
- 如果检测不到 MiniMessage API 或者转换失败，会自动回落到原有的 `colorify()`（`Hex.colorify` 渐变） 解析逻辑。

## 示例
```Title: '<rainbow>Profile'```
<img width="114" height="42" alt="image" src="https://github.com/user-attachments/assets/aa14ae7a-f4b0-4e11-a719-f72710f50257" />
