### PR TITLE
fix: 修复 Vault 经济功能与条件 Lore 刷新

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=me.arasple.mc.trmenu
-version=3.12.4
+version=3.12.5

--- a/plugin/src/main/kotlin/trplugins/menu/module/display/icon/IconProperty.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/display/icon/IconProperty.kt
@@ -27,7 +27,9 @@ class IconProperty(
     }
 
     fun isLoreUpdatable(session: MenuSession): Boolean {
-        return display.lore(session).cyclable() || display.lore(session).elements.any { it -> Regexs.containsPlaceholder(it.lore.joinToString(" ") { it.first }) }
+        return display.lore(session).cyclable() || display.lore(session).elements.any { lore ->
+            lore.lore.any { (line, condition) -> condition != null || Regexs.containsPlaceholder(line) }
+        }
     }
 
     fun handleClick(type: ReceptacleClickType, session: MenuSession) {

--- a/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookVault.kt
+++ b/plugin/src/main/kotlin/trplugins/menu/module/internal/hook/impl/HookVault.kt
@@ -63,14 +63,13 @@ class HookVault : HookAbstract() {
     /**
      * 当前 Economy provider 背后的实现插件实例。
      *
-     * provider 自身就是 Bukkit Plugin（兜底分支）时直接返回；
-     * 否则按 [Economy.getName] 在 Bukkit 插件表中匹配。
+     * ServicesManager provider 直接使用注册插件；
+     * 兜底 provider 自身就是 Bukkit Plugin。
      */
     val economyPlugin: Plugin?
         get() {
-            val provider = economyAPI ?: return null
-            return provider as? Plugin
-                ?: Bukkit.getPluginManager().getPlugin(provider.name)
+            val registration = Bukkit.getServicesManager().getRegistration(Economy::class.java)
+            return if (registration?.plugin?.isEnabled == true) registration.plugin else pluginEconomy as? Plugin
         }
 
     /**


### PR DESCRIPTION

- 修复 Vault Economy provider 无法正确关联实现插件的问题
- 修复带 `{condition}` 的 Lore 无法按照 `update` 配置动态刷新的问题 #269
- 小版本号+1